### PR TITLE
Feature/invert dependency on broker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 #COPY api/ api/
 COPY controllers/ controllers/
+COPY cmlib/ cmlib/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/cmlib/cmlib.go
+++ b/cmlib/cmlib.go
@@ -1,0 +1,42 @@
+package cmlib
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func LabelCM(ctx context.Context, r client.Client, configMap corev1.ConfigMap, labelKey string, labelValue string) error {
+	log := log.FromContext(ctx)
+	labels := configMap.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	labels[labelKey] = labelValue
+	configMap.SetLabels(labels)
+
+	if err := r.Update(ctx, &configMap); err != nil {
+		log.Error(err, "Unable to update configMap - setting labels")
+		return err
+	}
+	return nil
+}
+
+func AnnotateCM(ctx context.Context, r client.Client, configMap corev1.ConfigMap, annotationKey string, annotationValue string) error {
+	log := log.FromContext(ctx)
+	annotations := configMap.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[annotationKey] = annotationValue
+	configMap.SetAnnotations(annotations)
+
+	if err := r.Update(ctx, &configMap); err != nil {
+		log.Error(err, "Unable to update configMap - setting annotations")
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -84,7 +84,6 @@ func mqWriteObject(data []byte) error {
 	err = producer.Produce(data)
 
 	if err != nil {
-		//log.Error(err, "Unable to write to message broker")
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -61,8 +61,6 @@ var (
 	mqConfig                     mq.Config
 )
 
-const BROKER_PRODUCER_NAME = "lagoon-insights"
-
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -177,12 +175,6 @@ func main() {
 		},
 		DSN: fmt.Sprintf("amqp://%s:%s@%s/", mqUser, mqPass, mqHost),
 	}
-
-	//messageQ, err := mq.New(mqConfig)
-	//if err != nil {
-	//	log.Fatalf("Failed to set handler to consumer `%s`: %v", "consumer_name", err)
-	//	os.Exit(1)
-	//}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 

--- a/testdata/cm.yaml
+++ b/testdata/cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: game-demo
   labels:
-    lagoon.sh/insights: sbom
+    lagoon.sh/insightsType: sbom
 data:
   # property-like keys; each key maps to a simple value
   player_initial_lives: "3"


### PR DESCRIPTION
This PR inverts the dependency on the broker being available - rather than requiring it to be available on startup and for the duration of the service's life, it only opens a connection when needed.

Further, this provides some fallback and retry logic, so that if a configmap can't be written to the broker, it will retry in 5 minutes