### PR TITLE
Adds deletion endpoints to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ There are several parts to this - but from a user perspective it is fairly strai
 
 How this all works is coordinated across a few subsystems.
 
+#### Clearing facts and problems
+
+There are cases where clearing facts/problems for an environment _without_ writing a new set of insights.
+
+This is done by issuing a DELETE method call (with the authentication token in the header) to one of the following four endpoints
+
+* `http://lagoon-remote-insights-remote.lagoon.svc/facts/{SOURCE}`
+* `http://lagoon-remote-insights-remote.lagoon.svc/problems/{SOURCE}`
+* `http://lagoon-remote-insights-remote.lagoon.svc/facts/{SOURCE}/{SERVICE}`
+* `http://lagoon-remote-insights-remote.lagoon.svc/problems/{SOURCE}/{SERVICE}`
+
+Where `SOURCE` and `SERVICE` target the appropriate categorizations used generating the insights.
+
+Essentially these calls correspond to the "deleteProblemsFromSource" and "deleteFactsFromSource" Lagoon API calls
+
 #### Authorization Token
 
 The Authorization token is a JWT that is generated per project and environment by the insights-remote [namespace controller](controllers/namespace_controller.go)

--- a/internal/service/defs.go
+++ b/internal/service/defs.go
@@ -1,5 +1,8 @@
 package service
 
+const deleteFactsType = "direct.delete.facts"
+const deleteProblemsType = "direct.delete.problems"
+
 type DirectDeleteMessage struct {
 	Type          string `json:"type"`
 	EnvironmentId int    `json:"environmentId"`

--- a/internal/service/defs.go
+++ b/internal/service/defs.go
@@ -1,0 +1,15 @@
+package service
+
+type DeleteFactsMessage struct {
+	Type          string `json:"type"`
+	EnvironmentId int    `json:"environmentId"`
+	Source        string `json:"source"`
+	Service       string `json:"service"`
+}
+
+type DeleteProblemsMessage struct {
+	Type          string `json:"type"`
+	EnvironmentId int    `json:"environmentId"`
+	Source        string `json:"source"`
+	Service       string `json:"service"`
+}

--- a/internal/service/defs.go
+++ b/internal/service/defs.go
@@ -5,7 +5,7 @@ const deleteProblemsType = "direct.delete.problems"
 
 type DirectDeleteMessage struct {
 	Type          string `json:"type"`
-	EnvironmentId int    `json:"environmentId"`
+	EnvironmentId int    `json:"environment"`
 	Source        string `json:"source"`
 	Service       string `json:"service"`
 }

--- a/internal/service/defs.go
+++ b/internal/service/defs.go
@@ -1,13 +1,6 @@
 package service
 
-type DeleteFactsMessage struct {
-	Type          string `json:"type"`
-	EnvironmentId int    `json:"environmentId"`
-	Source        string `json:"source"`
-	Service       string `json:"service"`
-}
-
-type DeleteProblemsMessage struct {
+type DirectDeleteMessage struct {
 	Type          string `json:"type"`
 	EnvironmentId int    `json:"environmentId"`
 	Source        string `json:"source"`

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -23,9 +23,6 @@ type routerInstance struct {
 	WriteToQueue   bool
 }
 
-const deleteFactsType = "direct.delete.facts"
-const deleteProblemsType = "direct.delete.problems"
-
 func SetupRouter(secret string, messageQWriter func(data []byte) error, writeToQueue bool) *gin.Engine {
 	router := gin.Default()
 	r := routerInstance{secret: secret}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -76,7 +76,7 @@ func generateDeletionMessage(c *gin.Context, r *routerInstance, deletionType str
 		return
 	}
 
-	message := DeleteFactsMessage{
+	message := DirectDeleteMessage{
 		Type:          deletionType,
 		EnvironmentId: int(envid),
 		Source:        source,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -23,6 +23,9 @@ type routerInstance struct {
 	WriteToQueue   bool
 }
 
+const deleteFactsType = "direct.delete.facts"
+const deleteProblemsType = "direct.delete.problems"
+
 func SetupRouter(secret string, messageQWriter func(data []byte) error, writeToQueue bool) *gin.Engine {
 	router := gin.Default()
 	r := routerInstance{secret: secret}
@@ -30,7 +33,70 @@ func SetupRouter(secret string, messageQWriter func(data []byte) error, writeToQ
 	r.WriteToQueue = writeToQueue
 	router.POST("/facts", r.writeFacts)
 	router.POST("/problems", r.writeProblems)
+	router.DELETE("/problems/:source", r.deleteProblems)
+	router.DELETE("/problems/:source/:service", r.deleteProblems)
+	router.DELETE("/facts/:source", r.deleteFacts)
+	router.DELETE("/facts/:source/:service", r.deleteFacts)
 	return router
+}
+
+func (r *routerInstance) deleteProblems(c *gin.Context) {
+	generateDeletionMessage(c, r, deleteProblemsType)
+}
+
+func (r *routerInstance) deleteFacts(c *gin.Context) {
+	generateDeletionMessage(c, r, deleteFactsType)
+}
+
+func generateDeletionMessage(c *gin.Context, r *routerInstance, deletionType string) {
+	h := &AuthHeader{}
+	if err := c.ShouldBindHeader(&h); err != nil {
+		c.JSON(http.StatusOK, err)
+	}
+
+	namespace, err := tokens.ValidateAndExtractNamespaceDetailsFromToken(r.secret, h.Authorization)
+
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"status":  "unauthorized",
+			"message": err.Error(),
+		})
+		return
+	}
+
+	source := c.Params.ByName("source")
+	service := c.Params.ByName("service")
+
+	envid, err := strconv.ParseInt(namespace.EnvironmentId, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"status":  "BAD REQUEST",
+			"message": err.Error(),
+		})
+		return
+	}
+
+	message := DeleteFactsMessage{
+		Type:          deletionType,
+		EnvironmentId: int(envid),
+		Source:        source,
+		Service:       service,
+	}
+
+	jsonRep, err := json.Marshal(message)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := r.writeToQueue(c, err, jsonRep); err != nil {
+		c.JSON(http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "okay",
+	})
 }
 
 func (r *routerInstance) writeProblems(c *gin.Context) {
@@ -95,19 +161,26 @@ func (r *routerInstance) writeProblems(c *gin.Context) {
 		return
 	}
 
-	if r.WriteToQueue {
-		err = r.MessageQWriter(jsonRep)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, err)
-			return
-		}
-	} else {
-		fmt.Printf("Not writing to queue - would have sent these data %v\n", string(jsonRep))
+	if err := r.writeToQueue(c, err, jsonRep); err != nil {
+		c.JSON(http.StatusInternalServerError, err)
+		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "okay",
 	})
+}
+
+func (r *routerInstance) writeToQueue(c *gin.Context, err error, jsonRep []byte) error {
+	if r.WriteToQueue {
+		err = r.MessageQWriter(jsonRep)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("Not writing to queue - would have sent these data %v\n", string(jsonRep))
+	}
+	return nil
 }
 
 func (r *routerInstance) writeFacts(c *gin.Context) {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -142,3 +142,49 @@ func TestWriteProblemsRoute(t *testing.T) {
 
 	assert.Contains(t, queueWriterOutput, testProblems[0].Source)
 }
+
+func TestFactDeletionRoute(t *testing.T) {
+	defer resetWriterOutput()
+	router := SetupRouter(secretTestTokenSecret, messageQueueWriter, true)
+	w := httptest.NewRecorder()
+
+	token, err := tokens.GenerateTokenForNamespace(secretTestTokenSecret, tokens.NamespaceDetails{
+		Namespace:       secretTestNamespace,
+		EnvironmentId:   testEnvironmentId,
+		ProjectName:     "Test",
+		EnvironmentName: "Test",
+	})
+
+	require.NoError(t, err)
+
+	var bodyString []byte
+	req, _ := http.NewRequest(http.MethodDelete, "/facts/testsource", bytes.NewBuffer(bodyString))
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestProblemDeletionRoute(t *testing.T) {
+	defer resetWriterOutput()
+	router := SetupRouter(secretTestTokenSecret, messageQueueWriter, true)
+	w := httptest.NewRecorder()
+
+	token, err := tokens.GenerateTokenForNamespace(secretTestTokenSecret, tokens.NamespaceDetails{
+		Namespace:       secretTestNamespace,
+		EnvironmentId:   testEnvironmentId,
+		ProjectName:     "Test",
+		EnvironmentName: "Test",
+	})
+
+	require.NoError(t, err)
+
+	var bodyString []byte
+	req, _ := http.NewRequest(http.MethodDelete, "/problems/testsource", bytes.NewBuffer(bodyString))
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}


### PR DESCRIPTION
closes #17 

This PR introduces four new endpoints and a new pair of message types

* `direct.delete.facts`
* `direct.delete.problems`

Both send a message of the following structure to insights-handler

```
type DirectDeleteMessage struct {
	Type          string `json:"type"`
	EnvironmentId int    `json:"environmentId"`
	Source        string `json:"source"`
	Service       string `json:"service"`
}
```

This is used to drive the deletion of insights for an environment - with `Service` being optional.

Essentially these mirror the `deleteProblemsFromSource` and `deleteFactsFromSource` Lagoon core api calls.