### PR TITLE
Constraining incoming CM types

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -96,6 +96,13 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// insightsType is a way for us to classify incoming insights data, passing
+
+	log.Info("incoming labels")
+	for k, v := range configMap.Labels {
+		log.Info(fmt.Sprintf("%v:%v\n", k, v))
+	}
+	log.Info("incoming labels - end")
+
 	insightsType := "unclassified"
 	if _, ok := configMap.Labels["insights.lagoon.sh/type"]; ok {
 		insightsType = configMap.Labels["insights.lagoon.sh/type"]

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -96,20 +96,13 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// insightsType is a way for us to classify incoming insights data, passing
-
-	log.Info("incoming labels")
-	for k, v := range configMap.Labels {
-		log.Info(fmt.Sprintf("%v:%v\n", k, v))
-	}
-	log.Info("incoming labels - end")
-
 	insightsType := "unclassified"
 	if _, ok := configMap.Labels["insights.lagoon.sh/type"]; ok {
 		insightsType = configMap.Labels["insights.lagoon.sh/type"]
 		log.Info(fmt.Sprintf("Found insights.lagoon.sh/type:%v", insightsType))
 	} else {
 		// insightsType can be determined by the incoming data
-		if _, ok := labels["lagoon.sh/insightsType"]; ok {
+		if _, ok := configMap.Labels["lagoon.sh/insightsType"]; ok {
 			switch configMap.Labels["lagoon.sh/insightsType"] {
 			case ("sbom-gz"):
 				log.Info("Inferring insights type of sbom")

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -97,13 +97,13 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// insightsType is a way for us to classify incoming insights data, passing
 	insightsType := "unclassified"
-	if _, ok := labels["insights.lagoon.sh/type"]; ok {
-		insightsType = labels["insights.lagoon.sh/type"]
+	if _, ok := configMap.Labels["insights.lagoon.sh/type"]; ok {
+		insightsType = configMap.Labels["insights.lagoon.sh/type"]
 		log.Info(fmt.Sprintf("Found insights.lagoon.sh/type:%v", insightsType))
 	} else {
 		// insightsType can be determined by the incoming data
 		if _, ok := labels["lagoon.sh/insightsType"]; ok {
-			switch labels["lagoon.sh/insightsType"] {
+			switch configMap.Labels["lagoon.sh/insightsType"] {
 			case ("sbom-gz"):
 				log.Info("Inferring insights type of sbom")
 				insightsType = "sbom"


### PR DESCRIPTION
This PR is related to #19 - it does part of the work here to constrain outgoing configMap insights to only those currently added by the `build-deploy-tool`.

Anything that isn't able to be determined to be precisely an `inspect` or `sbom` type, either by inferrence (to support previous versions of the build-deploy tool), or explicitly typed as such with the `insights.lagoon.sh/type` label, are rejected.