### PR TITLE
Ignores terminating namespaces

### DIFF
--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -64,6 +64,11 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// if the namespace state is terminating, we do nothing
+	if ns.Status.Phase == corev1.NamespaceTerminating {
+		return ctrl.Result{}, nil
+	}
+
 	secretList := &corev1.SecretList{}
 
 	labelSelectorParameters, err := labels.NewRequirement(insightsTokenLabel, selection.Exists, []string{})
@@ -204,6 +209,7 @@ func activeNamespacePredicate(tokenTargetLabel string) predicate.Predicate {
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			labels := updateEvent.ObjectNew.GetLabels()
+
 			_, err := getValueFromMap(labels, "lagoon.sh/environmentId")
 			if err != nil {
 				return false


### PR DESCRIPTION
Right now the namespace controller will attempt to update the secret on ANY namespace object update - however, this logic fails in the case where a namespace is terminating / being deleted. This PR adds a check to ignore these cases.