### PR TITLE
Feature - dependency track integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/DependencyTrack/client-go v0.15.0 // indirect
 	github.com/NeowayLabs/wabbit v0.0.0-20210927194032-73ad61d1620e // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DependencyTrack/client-go v0.15.0 h1:IBaNq0yDKY99TwAsJ6xhKmmFYQWirGr2eF53I7uykqY=
+github.com/DependencyTrack/client-go v0.15.0/go.mod h1:T5iPG+foFcv6Bn5bTNbjywbmm+gwku4I1MuQWA77sR8=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/internal/defs.go
+++ b/internal/defs.go
@@ -45,3 +45,22 @@ type Problems struct {
 	Problems        []Problem `json:"problems"`
 	Type            string    `json:"type"`
 }
+
+type LagoonInsightsMessage struct {
+	Payload       map[string]string `json:"payload"`
+	BinaryPayload map[string][]byte `json:"binaryPayload"`
+	Annotations   map[string]string `json:"annotations"`
+	Labels        map[string]string `json:"labels"`
+	Environment   string            `json:"environment"`
+	Project       string            `json:"project"`
+	Type          string            `json:"type"`
+}
+
+// Insights Type consts
+const InsightsTypeSBOM = "sbom"
+const InsightsTypeInspect = "inspect"
+const InsightsTypeUnclassified = "unclassified"
+
+const InsightsLabel = "lagoon.sh/insightsType"
+const InsightsUpdatedAnnotationLabel = "lagoon.sh/insightsProcessed"
+const InsightsWriteDeferred = "lagoon.sh/insightsWriteDeferred"

--- a/internal/postprocess/dependencyTrack.go
+++ b/internal/postprocess/dependencyTrack.go
@@ -190,10 +190,8 @@ func (d *DependencyTrackPostProcess) PostProcess(message internal.LagoonInsights
 
 	select {
 	case <-doneChan:
-		fmt.Println("Uploaded!")
 		return nil
 	case err = <-errChan:
-		fmt.Println("Error!")
 		return err
 	}
 }

--- a/internal/postprocess/dependencyTrack.go
+++ b/internal/postprocess/dependencyTrack.go
@@ -1,0 +1,236 @@
+package postprocess
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	dtrack "github.com/DependencyTrack/client-go"
+	"io"
+	"lagoon.sh/insights-remote/internal"
+	"text/template"
+	"time"
+)
+
+type DependencyTrackTemplates struct {
+	RootProjectNameTemplate   string // If a root project is set, all subsequent projects will be children of this project
+	ParentProjectNameTemplate string
+	ProjectNameTemplate       string
+	VersionTemplate           string
+}
+
+type DependencyTrackPostProcess struct {
+	ApiEndpoint string
+	ApiKey      string
+	Templates   DependencyTrackTemplates
+}
+
+type dependencyTrackWriteInfo struct {
+	//RootName          string
+	ParentProjectName string
+	ProjectName       string
+	ProjectVersion    string
+}
+
+// This is a helper function to process a template string given a dependencyTrackWriteInfo struct
+func processTemplate(templateString string, info interface{}) (string, error) {
+	tmpl, err := template.New("templateString").Parse(templateString)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, info)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// Given a LagoonInsights message, we do a best effort to extract the necessary information to write to DependencyTrack
+func getWriteInfo(message internal.LagoonInsightsMessage, templates DependencyTrackTemplates) (dependencyTrackWriteInfo, error) {
+
+	writeinfo := dependencyTrackWriteInfo{}
+
+	// These are going to be what's available for templating
+	templateValues := struct {
+		ServiceName     string
+		ProjectName     string
+		EnvironmentName string
+		Version         string
+	}{}
+
+	if message.Project == "" {
+		if val, ok := message.Labels["lagoon.sh/project"]; ok {
+			templateValues.ProjectName = val
+		} else {
+			return writeinfo, fmt.Errorf("no project name found - unable to populate info for dependency track")
+		}
+	} else {
+		templateValues.ProjectName = message.Project
+	}
+
+	if message.Environment == "" {
+		if val, ok := message.Labels["lagoon.sh/environment"]; ok {
+			templateValues.EnvironmentName = val
+		} else {
+			return writeinfo, fmt.Errorf("no environment name found - unable to populate info for dependency track")
+		}
+	} else {
+		templateValues.EnvironmentName = message.Environment
+	}
+
+	if val, ok := message.Labels["lagoon.sh/service"]; ok {
+		templateValues.ServiceName = val
+	} else {
+		return writeinfo, fmt.Errorf("no service annotation found - unable to populate info for dependency track")
+	}
+
+	// okay - now we can populate the writeinfo struct with templating
+
+	if len(templates.ParentProjectNameTemplate) > 0 {
+		n, err := processTemplate(templates.ParentProjectNameTemplate, templateValues)
+		if err != nil {
+			return writeinfo, err
+		}
+		writeinfo.ParentProjectName = n
+	}
+
+	n, err := processTemplate(templates.ProjectNameTemplate, templateValues)
+	if err != nil {
+		return writeinfo, err
+	}
+	writeinfo.ProjectName = n
+
+	n, err = processTemplate(templates.VersionTemplate, templateValues)
+	if err != nil {
+		return writeinfo, err
+	}
+	writeinfo.ProjectVersion = n
+
+	return writeinfo, nil
+}
+
+func (d *DependencyTrackPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
+
+	// first, filter the type - we're only interested in sboms
+	if message.Type != internal.InsightsTypeSBOM {
+		return nil
+	}
+
+	// Now we pull out the necessary information to structure the write in terms of project name and parent.
+	writeInfo, err := getWriteInfo(message, d.Templates)
+	if err != nil {
+		return err
+	}
+
+	client, err := dtrack.NewClient(d.ApiEndpoint, dtrack.WithAPIKey(d.ApiKey))
+	if err != nil {
+		return err
+	}
+
+	// let's get or create the parent project
+	project, err := d.getOrCreateProject(client, writeInfo.ParentProjectName)
+	if err != nil {
+		return err
+	}
+
+	// let's now unzip the binary payload
+	var unzippedPayload bytes.Buffer
+	err = unzipByteStream(bytes.NewReader(message.BinaryPayload["output.zip"]), &unzippedPayload)
+
+	request := dtrack.BOMUploadRequest{
+		ProjectName:    writeInfo.ProjectName,
+		ParentUUID:     &project.UUID,
+		AutoCreate:     true,
+		ProjectVersion: writeInfo.ProjectVersion,
+		BOM:            base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()), //base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()),
+	}
+
+	uploadToken, err := client.BOM.Upload(context.TODO(), request)
+	if err != nil {
+		return err
+	}
+
+	const tickerHeartbeatDuration = 1 * time.Second
+	const tickerTimeout = 30 * time.Second
+
+	var (
+		doneChan = make(chan struct{})
+		errChan  = make(chan error)
+		ticker   = time.NewTicker(tickerHeartbeatDuration)
+		timeout  = time.After(tickerTimeout)
+	)
+
+	go func() {
+		defer func() {
+			close(doneChan)
+			close(errChan)
+		}()
+
+		for {
+			select {
+			case <-ticker.C:
+				processing, err := client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(uploadToken))
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if !processing {
+					doneChan <- struct{}{}
+					return
+				}
+			case <-timeout:
+				errChan <- fmt.Errorf("timeout exceeded")
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-doneChan:
+		fmt.Println("Uploaded!")
+		return nil
+	case err = <-errChan:
+		fmt.Println("Error!")
+		return err
+	}
+}
+
+// This will get or create a project in DependencyTrack
+func (d *DependencyTrackPostProcess) getOrCreateProject(client *dtrack.Client, projectName string) (dtrack.Project, error) {
+	// let's ensure we have a parent project
+	var project dtrack.Project
+	projects, err := client.Project.GetProjectsForName(context.TODO(), projectName, true, true)
+	if err != nil {
+		return dtrack.Project{}, err
+	}
+
+	// let's create the parent project if it doesn't exist
+	if len(projects) == 0 {
+		project, err = client.Project.Create(context.TODO(), dtrack.Project{
+			Name:   projectName,
+			Active: true,
+		})
+
+		if err != nil {
+			return dtrack.Project{}, err
+		}
+	} else {
+		project = projects[0]
+	}
+	return project, err
+}
+
+// Helper function to unzip a byte stream
+func unzipByteStream(input io.Reader, output io.Writer) error {
+	gzipReader, err := gzip.NewReader(input)
+	if err != nil {
+		return err
+	}
+	defer gzipReader.Close()
+
+	_, err = io.Copy(output, gzipReader)
+	return err
+}

--- a/internal/postprocess/dependencyTrack_test.go
+++ b/internal/postprocess/dependencyTrack_test.go
@@ -1,0 +1,204 @@
+package postprocess
+
+import (
+	"lagoon.sh/insights-remote/internal"
+	"reflect"
+	"testing"
+)
+
+func TestDependencyTrackPostProcess_processTemplate(t *testing.T) {
+	type fields struct {
+		ApiEndpoint               string
+		ApiKey                    string
+		RootProjectName           string
+		ParentProjectNameTemplate string
+		ProjectNameTemplate       string
+	}
+	type args struct {
+		info dependencyTrackWriteInfo
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "simple passing test",
+			fields: fields{
+				ParentProjectNameTemplate: "ParentProjectName",
+			},
+			args: args{
+				info: dependencyTrackWriteInfo{
+					ParentProjectName: "ParentProjectName",
+				},
+			},
+			want:    "ParentProjectName",
+			wantErr: false,
+		},
+		{
+			name: "template test",
+			fields: fields{
+				ParentProjectNameTemplate: "{{.ParentProjectName}}",
+			},
+			args: args{
+				info: dependencyTrackWriteInfo{
+					ParentProjectName: "ThisIsTheParentProjectName",
+				},
+			},
+			want:    "ThisIsTheParentProjectName",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &DependencyTrackPostProcess{
+				ApiEndpoint: tt.fields.ApiEndpoint,
+				ApiKey:      tt.fields.ApiKey,
+				Templates: DependencyTrackTemplates{
+					RootProjectNameTemplate:   tt.fields.RootProjectName,
+					ParentProjectNameTemplate: tt.fields.ParentProjectNameTemplate,
+					ProjectNameTemplate:       tt.fields.ProjectNameTemplate,
+				},
+			}
+			got, err := processTemplate(d.Templates.ParentProjectNameTemplate, tt.args.info)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetParentProjectName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetParentProjectName() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getWriteInfo(t *testing.T) {
+	type args struct {
+		message   internal.LagoonInsightsMessage
+		templates DependencyTrackTemplates
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    dependencyTrackWriteInfo
+		wantErr bool
+	}{
+		{
+			name: "Project, no parents",
+			args: args{
+				message: internal.LagoonInsightsMessage{
+					Labels: map[string]string{
+						"lagoon.sh/project":     "testprojectlabel",
+						"lagoon.sh/environment": "testenvironmentlabel",
+						"lagoon.sh/service":     "clilabel",
+					},
+					Project:     "testProject",
+					Environment: "testEnvironment",
+				},
+				templates: DependencyTrackTemplates{
+					RootProjectNameTemplate:   "",
+					ParentProjectNameTemplate: "",
+					ProjectNameTemplate:       "{{ .ProjectName }}-{{ .ServiceName }}",
+					VersionTemplate:           "1.0.0",
+				},
+			},
+			want: dependencyTrackWriteInfo{
+				ParentProjectName: "",
+				ProjectName:       "testProject-clilabel",
+				ProjectVersion:    "1.0.0",
+			},
+		},
+		{
+			name: "Project with parent",
+			args: args{
+				message: internal.LagoonInsightsMessage{
+					Labels: map[string]string{
+						"lagoon.sh/project":     "testprojectlabel",
+						"lagoon.sh/environment": "testenvironmentlabel",
+						"lagoon.sh/service":     "clilabel",
+					},
+					Project:     "testProject",
+					Environment: "testEnvironment",
+				},
+				templates: DependencyTrackTemplates{
+					RootProjectNameTemplate:   "",
+					ParentProjectNameTemplate: "testproject-{{ .ProjectName }}",
+					ProjectNameTemplate:       "{{ .ProjectName }}-{{ .ServiceName }}",
+					VersionTemplate:           "1.0.0",
+				},
+			},
+			want: dependencyTrackWriteInfo{
+				ParentProjectName: "testproject-testProject",
+				ProjectName:       "testProject-clilabel",
+				ProjectVersion:    "1.0.0",
+			},
+		},
+		{
+			name: "Project with root and parent",
+			args: args{
+				message: internal.LagoonInsightsMessage{
+					Labels: map[string]string{
+						"lagoon.sh/project":     "testprojectlabel",
+						"lagoon.sh/environment": "testenvironmentlabel",
+						"lagoon.sh/service":     "clilabel",
+					},
+					Project:     "testProject",
+					Environment: "testEnvironment",
+				},
+				templates: DependencyTrackTemplates{
+					RootProjectNameTemplate:   "SomeRootProject",
+					ParentProjectNameTemplate: "testproject-{{ .ProjectName }}",
+					ProjectNameTemplate:       "{{ .ProjectName }}-{{ .ServiceName }}",
+					VersionTemplate:           "1.0.0",
+				},
+			},
+
+			want: dependencyTrackWriteInfo{
+				ParentProjectName: "testproject-testProject",
+				ProjectName:       "testProject-clilabel",
+				ProjectVersion:    "1.0.0",
+			},
+		},
+		{
+			name: "Project falling back to labels",
+			args: args{
+				message: internal.LagoonInsightsMessage{
+					Labels: map[string]string{
+						"lagoon.sh/project":     "testprojectlabel",
+						"lagoon.sh/environment": "testenvironmentlabel",
+						"lagoon.sh/service":     "clilabel",
+					},
+					Project:     "",
+					Environment: "testEnvironment",
+				},
+				templates: DependencyTrackTemplates{
+					RootProjectNameTemplate:   "SomeRootProject",
+					ParentProjectNameTemplate: "testproject-{{ .ProjectName }}",
+					ProjectNameTemplate:       "{{ .ProjectName }}-{{ .ServiceName }}",
+					VersionTemplate:           "1.0.0",
+				},
+			},
+
+			want: dependencyTrackWriteInfo{
+				ParentProjectName: "testproject-testprojectlabel",
+				ProjectName:       "testprojectlabel-clilabel",
+				ProjectVersion:    "1.0.0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getWriteInfo(tt.args.message, tt.args.templates)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getWriteInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getWriteInfo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/postprocess/postprocess.go
+++ b/internal/postprocess/postprocess.go
@@ -1,0 +1,13 @@
+package postprocess
+
+import (
+	"lagoon.sh/insights-remote/internal"
+)
+
+type PostProcessor interface {
+	PostProcess(message internal.LagoonInsightsMessage) error
+}
+
+type PostProcessors struct {
+	PostProcessors []PostProcessor
+}

--- a/internal/tokens/jwt_test.go
+++ b/internal/tokens/jwt_test.go
@@ -24,15 +24,15 @@ func TestGenerateTokenForNamespace(t *testing.T) {
 				details: NamespaceDetails{
 					Namespace:       "Namespace",
 					EnvironmentId:   "1",
-					ProjectName:     "Project",
-					EnvironmentName: "Environment",
+					ProjectName:     "ProjectName",
+					EnvironmentName: "EnvironmentName",
 				},
 			},
 			want: NamespaceDetails{
 				Namespace:       "Namespace",
 				EnvironmentId:   "1",
-				ProjectName:     "Project",
-				EnvironmentName: "Environment",
+				ProjectName:     "ProjectName",
+				EnvironmentName: "EnvironmentName",
 			},
 		},
 		{
@@ -42,8 +42,8 @@ func TestGenerateTokenForNamespace(t *testing.T) {
 				details: NamespaceDetails{
 					Namespace:       "Namespace",
 					EnvironmentId:   "1",
-					ProjectName:     "Project",
-					EnvironmentName: "Environment",
+					ProjectName:     "ProjectName",
+					EnvironmentName: "EnvironmentName",
 				},
 			},
 			want: NamespaceDetails{

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"lagoon.sh/insights-remote/internal"
+	"lagoon.sh/insights-remote/internal/postprocess"
 	"log"
 	"os"
 	"strconv"
@@ -54,33 +56,39 @@ import (
 )
 
 var (
-	scheme                           = runtime.NewScheme()
-	setupLog                         = ctrl.Log.WithName("setup")
-	mqEnable                         bool
-	mqUser                           string
-	mqPass                           string
-	mqHost                           string
-	mqTLS                            bool
-	mqVerify                         bool
-	mqCACert                         string
-	mqClientCert                     string
-	mqClientKey                      string
-	rabbitReconnectRetryInterval     int
-	burnAfterReading                 bool
-	clearConfigmapCronSched          string
-	mqConfig                         mq.Config
-	insightsTokenSecret              string
-	enableNSReconciler               bool
-	enableCMReconciler               bool
-	enableInsightDeferred            bool //TODO: Better names for this
-	enableWebservice                 bool
-	tokenTargetLabel                 string
-	webservicePort                   string
-	generateTokenOnly                bool
-	generateTokenOnlyNamespace       string
-	generateTokenOnlyEnvironmentId   string
-	generateTokenOnlyProjectName     string
-	generateTokenOnlyEnvironmentName string
+	scheme                                   = runtime.NewScheme()
+	setupLog                                 = ctrl.Log.WithName("setup")
+	mqEnable                                 bool
+	mqUser                                   string
+	mqPass                                   string
+	mqHost                                   string
+	mqTLS                                    bool
+	mqVerify                                 bool
+	mqCACert                                 string
+	mqClientCert                             string
+	mqClientKey                              string
+	rabbitReconnectRetryInterval             int
+	burnAfterReading                         bool
+	clearConfigmapCronSched                  string
+	mqConfig                                 mq.Config
+	insightsTokenSecret                      string
+	enableNSReconciler                       bool
+	enableCMReconciler                       bool
+	enableInsightDeferred                    bool //TODO: Better names for this
+	enableWebservice                         bool
+	tokenTargetLabel                         string
+	webservicePort                           string
+	generateTokenOnly                        bool
+	generateTokenOnlyNamespace               string
+	generateTokenOnlyEnvironmentId           string
+	generateTokenOnlyProjectName             string
+	generateTokenOnlyEnvironmentName         string
+	enableDependencyTrackIntegration         bool
+	dependencyTrackApiEndpoint               string
+	dependencyTrackApiKey                    string
+	dependencyTrackProjectNameTemplate       string
+	dependencyTrackParentProjectNameTemplate string
+	dependencyTrackVersionTemplate           string
 )
 
 func init() {
@@ -171,11 +179,19 @@ func main() {
 
 	flag.StringVar(&generateTokenOnlyNamespace, "generate-token-only-namespace", "", "Namespace for which to generate a token.")
 
-	flag.StringVar(&generateTokenOnlyEnvironmentId, "generate-token-only-environment-id", "", "Environment ID for which to generate a token.")
+	flag.StringVar(&generateTokenOnlyEnvironmentId, "generate-token-only-environment-id", "", "EnvironmentName ID for which to generate a token.")
 
-	flag.StringVar(&generateTokenOnlyProjectName, "generate-token-only-project-name", "", "Project name for which to generate a token.")
+	flag.StringVar(&generateTokenOnlyProjectName, "generate-token-only-project-name", "", "ProjectName name for which to generate a token.")
 
-	flag.StringVar(&generateTokenOnlyEnvironmentName, "generate-token-only-environment-name", "", "Environment name for which to generate a token.")
+	flag.StringVar(&generateTokenOnlyEnvironmentName, "generate-token-only-environment-name", "", "EnvironmentName name for which to generate a token.")
+
+	// If these two are set, we will post to Dependency Track post-process
+	flag.BoolVar(&enableDependencyTrackIntegration, "enable-dependency-track-integration", false, "Enable Dependency Track integration.")
+	flag.StringVar(&dependencyTrackApiEndpoint, "dependency-track-api-endpoint", "", "The endpoint for the Dependency Track API.")
+	flag.StringVar(&dependencyTrackApiKey, "dependency-track-api-key", "", "The API key for the Dependency Track API.")
+	flag.StringVar(&dependencyTrackProjectNameTemplate, "dependency-track-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}", "The template for the project name in Dependency Track.")
+	flag.StringVar(&dependencyTrackParentProjectNameTemplate, "dependency-track-parent-project-name-template", "{{ .ProjectName }}", "The template for the parent project name in Dependency Track.")
+	flag.StringVar(&dependencyTrackVersionTemplate, "dependency-track-version-template", "unset", "The template for the version in Dependency Track.")
 
 	opts := zap.Options{
 		Development: true,
@@ -227,6 +243,14 @@ func main() {
 	if variables.GetEnv("BURN_AFTER_READING", "FALSE") == "TRUE" {
 		log.Printf("Burn-after-reading enabled via environment variable")
 		burnAfterReading = true
+	}
+	// Check if Dependency Track integration is enabled
+	enableDependencyTrackIntegration = variables.GetEnvBool("ENABLE_DEPENDENCY_TRACK_INTEGRATION", enableDependencyTrackIntegration)
+	dependencyTrackApiEndpoint = variables.GetEnv("DEPENDENCY_TRACK_API_ENDPOINT", dependencyTrackApiEndpoint)
+	dependencyTrackApiKey = variables.GetEnv("DEPENDENCY_TRACK_API_KEY", dependencyTrackApiKey)
+	// Check if Dependency Track integration is enabled - fail if missing required configuration
+	if enableDependencyTrackIntegration && (dependencyTrackApiEndpoint == "" || dependencyTrackApiKey == "") {
+		log.Fatal("Dependency Track integration enabled but missing required configuration")
 	}
 
 	brokerDSN := fmt.Sprintf("amqp://%s:%s@%s", mqUser, mqPass, mqHost)
@@ -302,12 +326,30 @@ func main() {
 	}
 
 	if enableCMReconciler {
+
+		// First, let's set up post processors
+		postProcessor := postprocess.PostProcessors{}
+
+		if enableDependencyTrackIntegration && dependencyTrackApiEndpoint != "" && dependencyTrackApiKey != "" {
+			postProcessor.PostProcessors = append(postProcessor.PostProcessors, &postprocess.DependencyTrackPostProcess{
+				ApiEndpoint: dependencyTrackApiEndpoint,
+				ApiKey:      dependencyTrackApiKey,
+				Templates: postprocess.DependencyTrackTemplates{
+					ParentProjectNameTemplate: dependencyTrackParentProjectNameTemplate,
+					ProjectNameTemplate:       dependencyTrackProjectNameTemplate,
+					VersionTemplate:           dependencyTrackVersionTemplate,
+				},
+			})
+		}
+
+		// Set up the controller
 		if err = (&controllers.ConfigMapReconciler{
 			Client:           mgr.GetClient(),
 			Scheme:           mgr.GetScheme(),
 			MessageQWriter:   mqWriteObject,
 			BurnAfterReading: burnAfterReading,
 			WriteToQueue:     mqEnable,
+			PostProcessors:   postProcessor,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ConfigMap")
 			os.Exit(1)
@@ -372,7 +414,7 @@ func startBurnAfterReadingCron(mgr manager.Manager) {
 	c.AddFunc(clearConfigmapCronSched, func() {
 		client := mgr.GetClient()
 		configMapList := &corev1.ConfigMapList{}
-		insightsProcessedRequirement, err := labels.NewRequirement(controllers.InsightsLabel, selection.Exists, []string{})
+		insightsProcessedRequirement, err := labels.NewRequirement(internal.InsightsLabel, selection.Exists, []string{})
 		if err != nil {
 			fmt.Printf("bad requirement: %v\n\n", err)
 			return
@@ -392,7 +434,7 @@ func startBurnAfterReadingCron(mgr manager.Manager) {
 
 		for _, x := range configMapList.Items {
 			//check the annotations
-			if _, okay := x.Annotations[controllers.InsightsUpdatedAnnotationLabel]; okay {
+			if _, okay := x.Annotations[internal.InsightsUpdatedAnnotationLabel]; okay {
 				//grab the build this is linked to
 				buildName := ""
 				if val, ok := x.Labels["lagoon.sh/buildName"]; ok {
@@ -415,7 +457,7 @@ func startInsightsDeferredClearCron(mgr manager.Manager) {
 
 		client := mgr.GetClient()
 		configMapList := &corev1.ConfigMapList{}
-		insightsDeferredRequirement, err := labels.NewRequirement(controllers.InsightsWriteDeferred, selection.Exists, []string{})
+		insightsDeferredRequirement, err := labels.NewRequirement(internal.InsightsWriteDeferred, selection.Exists, []string{})
 		if err != nil {
 			fmt.Printf("bad requirement: %v\n\n", err)
 			return
@@ -435,7 +477,7 @@ func startInsightsDeferredClearCron(mgr manager.Manager) {
 
 		for _, x := range configMapList.Items {
 			//check the labels
-			if writeDeferredVal, okay := x.Labels[controllers.InsightsWriteDeferred]; okay {
+			if writeDeferredVal, okay := x.Labels[internal.InsightsWriteDeferred]; okay {
 				writeDeferredValTS, _ := strconv.ParseInt(writeDeferredVal, 10, 32)
 				parsed := time.Unix(writeDeferredValTS, 0)
 				if err != nil {
@@ -444,7 +486,7 @@ func startInsightsDeferredClearCron(mgr manager.Manager) {
 				}
 
 				if time.Now().After(parsed) {
-					delete(x.Labels, controllers.InsightsWriteDeferred)
+					delete(x.Labels, internal.InsightsWriteDeferred)
 					err = client.Update(context.Background(), &x)
 					if err != nil {
 						log.Printf("Unable to update configmap '%v' for '%v' in ns '%v': %v\n\n", x.Name, x.Name, x.Namespace, err)


### PR DESCRIPTION
This PR represents introducing the notion of post processors for lagoon messages - allowing one to register a post-processor that will act on an outgoing message.

The first post-processor introduced is dependency track. This allows a insights-remote to push sboms to a dependency track instance. It requires an api endpoint and key to be passed into the service at startup.

It, further, introduces templates as a way of structuring how and where the data are written into Dependency track.