### PR TITLE
feat: support custom dependency track via Lagoon api env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,22 @@ These two routes simply unmarshal the data, use the authorization header to set 
 
 Insights remote allows integration into [Dependency Track](https://docs.dependencytrack.org/) - specifically, the uploading of SBOMS.
 
-Once a build is complete and the SBOM has been sent to Insights Core, a post-processing step is triggered and pushes the SBOM to Dependency Track.
+Once a build is complete and the SBOM has been sent to Insights Core, a post-processing step is triggered and pushes the SBOM to Dependency Track. There are two available post-processors: 1) A default integration which sends all insights to a central instance and 2) A custom integration configured via Lagoon API env vars.
 
 Dependency track integration is enabled by starting Insights Remote with the appropriate flags or the following environment variables in the insights-remote deployment:
 * ENABLE_DEPENDENCY_TRACK_INTEGRATION=true
+
+### Default Post-Processor
+
+The default integration is enabled by starting Insights Remote with the appropriate flags or the following environment variables in the insights-remote deployment:
 * DEPENDENCY_TRACK_API_ENDPOINT=https://dependency-track.example.com
 * DEPENDENCY_TRACK_API_KEY=your-api-key
+
+### Custom Post-Processor
+
+The custom integration is enabled by adding the following environment variables in the Lagoon API:
+* LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_ENDPOINT=https://dependency-track.example.com
+* LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY=your-api-key
 
 # Templates
 
@@ -127,4 +137,3 @@ The following variables are available for use in the templates:
 - .EnvironmentType
 
 These are currently set by overriding the arguments in the insights-remote deployment.
-

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -352,6 +352,15 @@ func main() {
 					},
 				})
 			}
+
+			postProcessor.PostProcessors = append(postProcessor.PostProcessors, &deptrack.CustomPostProcess{
+				Client: mgr.GetClient(),
+				Templates: deptrack.Templates{
+					ParentProjectNameTemplates: dtTemplates,
+					ProjectNameTemplate:        dependencyTrackProjectNameTemplate,
+					VersionTemplate:            dependencyTrackVersionTemplate,
+				},
+			})
 		}
 
 		// Set up the controller

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"time"
+
 	"k8s.io/apimachinery/pkg/types"
 	"lagoon.sh/insights-remote/internal"
 	"lagoon.sh/insights-remote/internal/postprocess"
-	"strconv"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -125,6 +125,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			BinaryPayload: configMap.BinaryData,
 			Annotations:   configMap.Annotations,
 			Labels:        configMap.Labels,
+			Namespace:     configMap.Namespace,
 			Environment:   environmentName,
 			Project:       projectName,
 			Type:          insightsType,

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -144,9 +144,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			log.Error(err, "Unable to write to message broker")
 
 			//In this case what we want to do is defer the processing to a couple minutes from now
-			future := time.Minute * 5
-			futureTime := time.Now().Add(future).Unix()
-			err = cmlib.LabelCM(ctx, r.Client, configMap, internal.InsightsWriteDeferred, strconv.FormatInt(futureTime, 10))
+			err = cmlib.LabelCM(ctx, r.Client, configMap, internal.InsightsWriteDeferred, minutesFromNow(5))
 
 			if err != nil {
 				log.Error(err, "Unable to update configmap")
@@ -158,19 +156,33 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	}
 
+	// Here we run the post processors
+	retryPostprocessing := false
+	for _, processor := range r.PostProcessors.PostProcessors {
+		err := processor.PostProcess(insightsMessage)
+		if err != nil {
+			log.Error(err, "Post processor failed")
+			retryPostprocessing = true
+		}
+	}
+
+	if retryPostprocessing {
+		//In this case what we want to do is defer the processing to a couple minutes from now
+		err := cmlib.LabelCM(ctx, r.Client, configMap, internal.InsightsWriteDeferred, minutesFromNow(5))
+
+		if err != nil {
+			log.Error(err, "Unable to update configmap")
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, err
+	}
+
 	err := cmlib.AnnotateCM(ctx, r.Client, configMap, internal.InsightsUpdatedAnnotationLabel, time.Now().UTC().Format(time.RFC3339))
 
 	if err != nil {
 		log.Error(err, "Unable to update configmap")
 		return ctrl.Result{}, err
-	}
-
-	// Here we run the post processors
-	for _, processor := range r.PostProcessors.PostProcessors {
-		err := processor.PostProcess(insightsMessage)
-		if err != nil {
-			log.Error(err, "Post processor failed")
-		}
 	}
 
 	return ctrl.Result{}, nil
@@ -227,4 +239,9 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.ConfigMap{}).
 		WithEventFilter(insightLabelsOnlyPredicate()).
 		Complete(r)
+}
+
+func minutesFromNow(mins int) string {
+	xMins := time.Minute * time.Duration(mins)
+	return strconv.FormatInt(time.Now().Add(xMins).Unix(), 10)
 }

--- a/internal/defs.go
+++ b/internal/defs.go
@@ -51,6 +51,7 @@ type LagoonInsightsMessage struct {
 	BinaryPayload map[string][]byte `json:"binaryPayload"`
 	Annotations   map[string]string `json:"annotations"`
 	Labels        map[string]string `json:"labels"`
+	Namespace     string            `json:"namespace"`
 	Environment   string            `json:"environment"`
 	Service       string            `json:"service"`
 	Project       string            `json:"project"`

--- a/internal/postprocess/dependency_track/custom_postprocess.go
+++ b/internal/postprocess/dependency_track/custom_postprocess.go
@@ -1,0 +1,53 @@
+package deptrack
+
+import (
+	"context"
+	"fmt"
+
+	dtrack "github.com/DependencyTrack/client-go"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"lagoon.sh/insights-remote/internal"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CustomPostProcess will send insights for a namespace to a Dependency Track instance configured
+// for that namespace.
+type CustomPostProcess struct {
+	Client    client.Client
+	Templates Templates
+}
+
+func (d *CustomPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
+	// Only send SBOMs
+	if message.Type != internal.InsightsTypeSBOM {
+		return nil
+	}
+
+	apiEndpoint := message.Annotations["dependencytrack.insights.lagoon.sh/custom-endpoint"]
+	if apiEndpoint == "" {
+		return nil
+	}
+
+	var secret corev1.Secret
+	if err := d.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: message.Namespace,
+		Name:      "lagoon-env",
+	}, &secret); err != nil {
+		return fmt.Errorf("failed to load custom key: %w", err)
+	}
+
+	if len(secret.Data["LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY"]) == 0 {
+		return fmt.Errorf("failed to load custom key")
+	}
+
+	apiKey := string(secret.Data["LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY"])
+
+	client, err := dtrack.NewClient(apiEndpoint, dtrack.WithAPIKey(apiKey))
+	if err != nil {
+		return err
+	}
+
+	err = postProcess(message, d.Templates, client)
+	return err
+}

--- a/internal/postprocess/dependency_track/default_postprocess.go
+++ b/internal/postprocess/dependency_track/default_postprocess.go
@@ -1,0 +1,126 @@
+package deptrack
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	dtrack "github.com/DependencyTrack/client-go"
+	"lagoon.sh/insights-remote/internal"
+)
+
+// DefaultPostProcess will send insights for all namespaces to a central Dependency Track instance.
+type DefaultPostProcess struct {
+	ApiEndpoint string
+	ApiKey      string
+	Templates   Templates
+}
+
+func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
+
+	// first, filter the type - we're only interested in sboms
+	if message.Type != internal.InsightsTypeSBOM {
+		return nil
+	}
+
+	// Now we pull out the necessary information to structure the write in terms of project name and parent.
+	writeInfo, err := getWriteInfo(message, d.Templates)
+	if err != nil {
+		return err
+	}
+
+	client, err := dtrack.NewClient(d.ApiEndpoint, dtrack.WithAPIKey(d.ApiKey))
+	if err != nil {
+		return err
+	}
+
+	// Here we iterate over the parent projects, creating them if/when we need
+	// only the last one gets passed to the upload
+	var project *dtrack.Project
+	for _, projectName := range writeInfo.ParentProjectNames {
+		var parentRef *dtrack.ParentRef
+		if project != nil {
+			parentRef = &dtrack.ParentRef{UUID: project.UUID}
+		}
+		projectObj, err := getOrCreateProject(client, projectName, parentRef)
+		if err != nil {
+			return err
+		}
+		project = &projectObj
+	}
+
+	// let's now unzip the binary payload
+	var unzippedPayload bytes.Buffer
+
+	// we need to pull the binary payload out of the message
+	// get the first item from map
+	var messageBinaryPayload []byte
+	for _, v := range message.BinaryPayload {
+		messageBinaryPayload = v
+		break
+	}
+
+	err = unzipByteStream(bytes.NewReader(messageBinaryPayload), &unzippedPayload)
+
+	if err != nil {
+		return err
+	}
+
+	request := dtrack.BOMUploadRequest{
+		ProjectName:    writeInfo.ProjectName,
+		ParentUUID:     &project.UUID,
+		AutoCreate:     true,
+		ProjectVersion: writeInfo.ProjectVersion,
+		BOM:            base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()), //base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()),
+	}
+
+	uploadToken, err := client.BOM.Upload(context.TODO(), request)
+	if err != nil {
+		return err
+	}
+
+	const tickerHeartbeatDuration = 1 * time.Second
+	const tickerTimeout = 300 * time.Second
+
+	var (
+		doneChan = make(chan struct{})
+		errChan  = make(chan error)
+		ticker   = time.NewTicker(tickerHeartbeatDuration)
+		timeout  = time.After(tickerTimeout)
+	)
+
+	go func() {
+		defer func() {
+			ticker.Stop()
+			close(doneChan)
+			close(errChan)
+		}()
+
+		for {
+			select {
+			case <-ticker.C:
+				processing, err := client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(uploadToken))
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if !processing {
+					doneChan <- struct{}{}
+					return
+				}
+			case <-timeout:
+				errChan <- fmt.Errorf("timeout exceeded")
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-doneChan:
+		return nil
+	case err = <-errChan:
+		return err
+	}
+}

--- a/internal/postprocess/dependency_track/default_postprocess.go
+++ b/internal/postprocess/dependency_track/default_postprocess.go
@@ -1,12 +1,6 @@
 package deptrack
 
 import (
-	"bytes"
-	"context"
-	"encoding/base64"
-	"fmt"
-	"time"
-
 	dtrack "github.com/DependencyTrack/client-go"
 	"lagoon.sh/insights-remote/internal"
 )
@@ -19,16 +13,9 @@ type DefaultPostProcess struct {
 }
 
 func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
-
-	// first, filter the type - we're only interested in sboms
+	// Only send SBOMs
 	if message.Type != internal.InsightsTypeSBOM {
 		return nil
-	}
-
-	// Now we pull out the necessary information to structure the write in terms of project name and parent.
-	writeInfo, err := getWriteInfo(message, d.Templates)
-	if err != nil {
-		return err
 	}
 
 	client, err := dtrack.NewClient(d.ApiEndpoint, dtrack.WithAPIKey(d.ApiKey))
@@ -36,91 +23,6 @@ func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage)
 		return err
 	}
 
-	// Here we iterate over the parent projects, creating them if/when we need
-	// only the last one gets passed to the upload
-	var project *dtrack.Project
-	for _, projectName := range writeInfo.ParentProjectNames {
-		var parentRef *dtrack.ParentRef
-		if project != nil {
-			parentRef = &dtrack.ParentRef{UUID: project.UUID}
-		}
-		projectObj, err := getOrCreateProject(client, projectName, parentRef)
-		if err != nil {
-			return err
-		}
-		project = &projectObj
-	}
-
-	// let's now unzip the binary payload
-	var unzippedPayload bytes.Buffer
-
-	// we need to pull the binary payload out of the message
-	// get the first item from map
-	var messageBinaryPayload []byte
-	for _, v := range message.BinaryPayload {
-		messageBinaryPayload = v
-		break
-	}
-
-	err = unzipByteStream(bytes.NewReader(messageBinaryPayload), &unzippedPayload)
-
-	if err != nil {
-		return err
-	}
-
-	request := dtrack.BOMUploadRequest{
-		ProjectName:    writeInfo.ProjectName,
-		ParentUUID:     &project.UUID,
-		AutoCreate:     true,
-		ProjectVersion: writeInfo.ProjectVersion,
-		BOM:            base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()), //base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()),
-	}
-
-	uploadToken, err := client.BOM.Upload(context.TODO(), request)
-	if err != nil {
-		return err
-	}
-
-	const tickerHeartbeatDuration = 1 * time.Second
-	const tickerTimeout = 300 * time.Second
-
-	var (
-		doneChan = make(chan struct{})
-		errChan  = make(chan error)
-		ticker   = time.NewTicker(tickerHeartbeatDuration)
-		timeout  = time.After(tickerTimeout)
-	)
-
-	go func() {
-		defer func() {
-			ticker.Stop()
-			close(doneChan)
-			close(errChan)
-		}()
-
-		for {
-			select {
-			case <-ticker.C:
-				processing, err := client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(uploadToken))
-				if err != nil {
-					errChan <- err
-					return
-				}
-				if !processing {
-					doneChan <- struct{}{}
-					return
-				}
-			case <-timeout:
-				errChan <- fmt.Errorf("timeout exceeded")
-				return
-			}
-		}
-	}()
-
-	select {
-	case <-doneChan:
-		return nil
-	case err = <-errChan:
-		return err
-	}
+	err = postProcess(message, d.Templates, client)
+	return err
 }

--- a/internal/postprocess/dependency_track/dependencyTrack.go
+++ b/internal/postprocess/dependency_track/dependencyTrack.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"text/template"
+	"time"
 
 	dtrack "github.com/DependencyTrack/client-go"
 	"lagoon.sh/insights-remote/internal"
@@ -164,4 +166,100 @@ func unzipByteStream(input io.Reader, output io.Writer) error {
 
 	_, err = io.Copy(output, gzipReader)
 	return err
+}
+
+func postProcess(message internal.LagoonInsightsMessage, templates Templates, client *dtrack.Client) error {
+	// Now we pull out the necessary information to structure the write in terms of project name and parent.
+	writeInfo, err := getWriteInfo(message, templates)
+	if err != nil {
+		return err
+	}
+
+	// Here we iterate over the parent projects, creating them if/when we need
+	// only the last one gets passed to the upload
+	var project *dtrack.Project
+	for _, projectName := range writeInfo.ParentProjectNames {
+		var parentRef *dtrack.ParentRef
+		if project != nil {
+			parentRef = &dtrack.ParentRef{UUID: project.UUID}
+		}
+		projectObj, err := getOrCreateProject(client, projectName, parentRef)
+		if err != nil {
+			return err
+		}
+		project = &projectObj
+	}
+
+	// let's now unzip the binary payload
+	var unzippedPayload bytes.Buffer
+
+	// we need to pull the binary payload out of the message
+	// get the first item from map
+	var messageBinaryPayload []byte
+	for _, v := range message.BinaryPayload {
+		messageBinaryPayload = v
+		break
+	}
+
+	err = unzipByteStream(bytes.NewReader(messageBinaryPayload), &unzippedPayload)
+
+	if err != nil {
+		return err
+	}
+
+	request := dtrack.BOMUploadRequest{
+		ProjectName:    writeInfo.ProjectName,
+		ParentUUID:     &project.UUID,
+		AutoCreate:     true,
+		ProjectVersion: writeInfo.ProjectVersion,
+		BOM:            base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()), //base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()),
+	}
+
+	uploadToken, err := client.BOM.Upload(context.TODO(), request)
+	if err != nil {
+		return err
+	}
+
+	const tickerHeartbeatDuration = 1 * time.Second
+	const tickerTimeout = 300 * time.Second
+
+	var (
+		doneChan = make(chan struct{})
+		errChan  = make(chan error)
+		ticker   = time.NewTicker(tickerHeartbeatDuration)
+		timeout  = time.After(tickerTimeout)
+	)
+
+	go func() {
+		defer func() {
+			ticker.Stop()
+			close(doneChan)
+			close(errChan)
+		}()
+
+		for {
+			select {
+			case <-ticker.C:
+				processing, err := client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(uploadToken))
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if !processing {
+					doneChan <- struct{}{}
+					return
+				}
+			case <-timeout:
+				errChan <- fmt.Errorf("timeout exceeded")
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-doneChan:
+		return nil
+	case err = <-errChan:
+		return err
+	}
 }

--- a/internal/postprocess/dependency_track/dependencyTrack.go
+++ b/internal/postprocess/dependency_track/dependencyTrack.go
@@ -1,19 +1,18 @@
-package postprocess
+package deptrack
 
 import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"fmt"
-	dtrack "github.com/DependencyTrack/client-go"
 	"io"
-	"lagoon.sh/insights-remote/internal"
 	"text/template"
-	"time"
+
+	dtrack "github.com/DependencyTrack/client-go"
+	"lagoon.sh/insights-remote/internal"
 )
 
-type DependencyTrackTemplates struct {
+type Templates struct {
 	//RootProjectNameTemplate   string // If a root project is set, all subsequent projects will be children of this project
 	//ParentProjectNameTemplate string
 	ParentProjectNameTemplates []string
@@ -21,13 +20,7 @@ type DependencyTrackTemplates struct {
 	VersionTemplate            string
 }
 
-type DependencyTrackPostProcess struct {
-	ApiEndpoint string
-	ApiKey      string
-	Templates   DependencyTrackTemplates
-}
-
-type dependencyTrackWriteInfo struct {
+type writeInfo struct {
 	//RootName          string
 	ParentProjectNames []string
 	ProjectName        string
@@ -50,9 +43,9 @@ func processTemplate(templateString string, info interface{}) (string, error) {
 }
 
 // Given a LagoonInsights message, we do a best effort to extract the necessary information to write to DependencyTrack
-func getWriteInfo(message internal.LagoonInsightsMessage, templates DependencyTrackTemplates) (dependencyTrackWriteInfo, error) {
+func getWriteInfo(message internal.LagoonInsightsMessage, templates Templates) (writeInfo, error) {
 
-	writeinfo := dependencyTrackWriteInfo{}
+	writeinfo := writeInfo{}
 
 	// These are going to be what's available for templating
 	templateValues := struct {
@@ -118,115 +111,8 @@ func getWriteInfo(message internal.LagoonInsightsMessage, templates DependencyTr
 	return writeinfo, nil
 }
 
-func (d *DependencyTrackPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
-
-	// first, filter the type - we're only interested in sboms
-	if message.Type != internal.InsightsTypeSBOM {
-		return nil
-	}
-
-	// Now we pull out the necessary information to structure the write in terms of project name and parent.
-	writeInfo, err := getWriteInfo(message, d.Templates)
-	if err != nil {
-		return err
-	}
-
-	client, err := dtrack.NewClient(d.ApiEndpoint, dtrack.WithAPIKey(d.ApiKey))
-	if err != nil {
-		return err
-	}
-
-	// Here we iterate over the parent projects, creating them if/when we need
-	// only the last one gets passed to the upload
-	var project *dtrack.Project
-	for _, projectName := range writeInfo.ParentProjectNames {
-		var parentRef *dtrack.ParentRef
-		if project != nil {
-			parentRef = &dtrack.ParentRef{UUID: project.UUID}
-		}
-		projectObj, err := d.getOrCreateProject(client, projectName, parentRef)
-		if err != nil {
-			return err
-		}
-		project = &projectObj
-	}
-
-	// let's now unzip the binary payload
-	var unzippedPayload bytes.Buffer
-
-	// we need to pull the binary payload out of the message
-	// get the first item from map
-	var messageBinaryPayload []byte
-	for _, v := range message.BinaryPayload {
-		messageBinaryPayload = v
-		break
-	}
-
-	err = unzipByteStream(bytes.NewReader(messageBinaryPayload), &unzippedPayload)
-
-	if err != nil {
-		return err
-	}
-
-	request := dtrack.BOMUploadRequest{
-		ProjectName:    writeInfo.ProjectName,
-		ParentUUID:     &project.UUID,
-		AutoCreate:     true,
-		ProjectVersion: writeInfo.ProjectVersion,
-		BOM:            base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()), //base64.StdEncoding.EncodeToString(unzippedPayload.Bytes()),
-	}
-
-	uploadToken, err := client.BOM.Upload(context.TODO(), request)
-	if err != nil {
-		return err
-	}
-
-	const tickerHeartbeatDuration = 1 * time.Second
-	const tickerTimeout = 300 * time.Second
-
-	var (
-		doneChan = make(chan struct{})
-		errChan  = make(chan error)
-		ticker   = time.NewTicker(tickerHeartbeatDuration)
-		timeout  = time.After(tickerTimeout)
-	)
-
-	go func() {
-		defer func() {
-			ticker.Stop()
-			close(doneChan)
-			close(errChan)
-		}()
-
-		for {
-			select {
-			case <-ticker.C:
-				processing, err := client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(uploadToken))
-				if err != nil {
-					errChan <- err
-					return
-				}
-				if !processing {
-					doneChan <- struct{}{}
-					return
-				}
-			case <-timeout:
-				errChan <- fmt.Errorf("timeout exceeded")
-				return
-			}
-		}
-	}()
-
-	select {
-	case <-doneChan:
-		return nil
-	case err = <-errChan:
-		return err
-	}
-}
-
 // This will get or create a project in DependencyTrack
-func (d *DependencyTrackPostProcess) getOrCreateProject(client *dtrack.Client, projectName string, parentProject *dtrack.ParentRef) (dtrack.Project, error) {
+func getOrCreateProject(client *dtrack.Client, projectName string, parentProject *dtrack.ParentRef) (dtrack.Project, error) {
 	// let's ensure we have a parent project
 	var project dtrack.Project
 	projects, err := client.Project.GetProjectsForName(context.TODO(), projectName, true, false)

--- a/internal/postprocess/postprocess.go
+++ b/internal/postprocess/postprocess.go
@@ -5,6 +5,7 @@ import (
 )
 
 type PostProcessor interface {
+	// PostProcess processes insights for 3rd party tools. Must be idempotent.
 	PostProcess(message internal.LagoonInsightsMessage) error
 }
 


### PR DESCRIPTION
In order to support dependency track integration in a more granular level, support for custom Dependency Track endpoints is added as a second post-processing step. `insights-remote` will check SBOM configmaps for the annotation `insights.lagoon.sh/dependency_track_custom_endpoint` to see if the insights should be sent to a custom Dependency Track. There must also be an env var in `secret/lagoon-env` called `LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY` which is done by adding it as a Lagoon API env var.

The Dependency Track integration for the remote must be enabled.

Also changes the logic of the postprocessors so that a failure will cause insights-remote to retry again later.