### PR TITLE
feat: optional core insights

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,34 +101,53 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-func mqWriteObject(data []byte) error {
-	messageQ, err := mq.New(mqConfig)
-	if err != nil {
-		//TODO: Log useful data here ...
-		return err
-	}
-	defer messageQ.Close()
-
-	producer, err := messageQ.SyncProducer("lagoon-insights")
-	if err != nil {
-		//log.Error(err, "Unable to write to message broker")
-		return err
-	}
-
-	err = producer.Produce(data)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func main() {
+
+	/*
+	 * Command flags.
+	 */
+
+	// Insights processing.
+	flag.BoolVar(&enableCMReconciler, "enable-configmap-reconciler", true,
+		"Enable the configmap reconciler (env var: ENABLE_CONFIGMAP_RECONCILER).")
+	flag.BoolVar(&burnAfterReading, "burn-after-reading", false,
+		"Remove insights configmaps after they have been processed (env var: BURN_AFTER_READING).")
+	flag.StringVar(&clearConfigmapCronSched, "clear-configmap-sched", "* * * * *",
+		"The cron schedule specifying how often insightType configmaps should be cleared (env var: CLEAR_CONFIGMAP_SCHED).")
+	flag.BoolVar(&enableInsightDeferred, "enable-insights-deferred", false,
+		"Delete insights after certain time (env var: ENABLE_INSIGHTS_DEFERRED).")
+
+	// Insights shipping: web service.
+	flag.BoolVar(&enableNSReconciler, "enable-namespace-reconciler", true,
+		"enable-namespace-reconciler (env var: ENABLE_NAMESPACE_RECONCILER).")
+	flag.BoolVar(&enableWebservice, "enable-webservice", true,
+		"Enables json endpoint for writing insights data (env var: ENABLE_WEBSERVICE).")
+	flag.StringVar(&webservicePort, "webservice-port", "8888",
+		"Port on which we expose the JSON webservice (env var: WEBSERVICE_PORT).")
+	flag.StringVar(&insightsTokenSecret, "insights-token-secret", "testsecret",
+		"The secret used to create the insights tokens used to communicate back to the webservice (env var: INSIGHTS_TOKEN_SECRET).")
+	flag.StringVar(&tokenTargetLabel, "token-target-label", "",
+		"Constrain webservice token generation to namespaces with this label (env var: TOKEN_TARGET_LABEL).")
+
+	// Insights shipping: Dependency Track.
+	flag.BoolVar(&enableDependencyTrackIntegration, "enable-dependency-track-integration", false, "Enable Dependency Track integration.")
+	flag.StringVar(&dependencyTrackApiEndpoint, "dependency-track-api-endpoint", "", "The endpoint for the Dependency Track API.")
+	flag.StringVar(&dependencyTrackApiKey, "dependency-track-api-key", "", "The API key for the Dependency Track API.")
+	flag.StringVar(&dependencyTrackRootProjectNameTemplate, "dependency-track-root-project-name-template", "{{ .ProjectName }}", "The template for the root project name in Dependency Track.")
+	flag.StringVar(&dependencyTrackParentProjectNameTemplate, "dependency-track-parent-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}", "The template for the parent project name in Dependency Track.")
+	flag.StringVar(&dependencyTrackProjectNameTemplate, "dependency-track-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}-{{ .ServiceName }}", "The template for the project name in Dependency Track.")
+	flag.StringVar(&dependencyTrackVersionTemplate, "dependency-track-version-template", "unset", "The template for the version in Dependency Track.")
+
+	// Controller.
+	var enableLeaderElection bool
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+
+	// Metrics.
 	var metricsAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	var enableLeaderElection bool
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -137,9 +156,8 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+
+	// RMQ.
 	flag.BoolVar(&mqEnable, "rabbitmq-enabled", true,
 		"Used primarily for debugging to disable the Message Broker connection (env var: RABBITMQ_ENABLED).")
 	flag.StringVar(&mqUser, "rabbitmq-username", "guest",
@@ -160,58 +178,23 @@ func main() {
 		"The path to the client key")
 	flag.IntVar(&rabbitReconnectRetryInterval, "rabbitmq-reconnect-retry-interval", 30,
 		"The retry interval for rabbitmq.")
-	flag.BoolVar(&burnAfterReading, "burn-after-reading", false,
-		"Remove insights configmaps after they have been processed (env var: BURN_AFTER_READING).")
-	flag.StringVar(&clearConfigmapCronSched, "clear-configmap-sched", "* * * * *",
-		"The cron schedule specifying how often insightType configmaps should be cleared (env var: CLEAR_CONFIGMAP_SCHED).")
 
-	flag.StringVar(&insightsTokenSecret, "insights-token-secret", "testsecret",
-		"The secret used to create the insights tokens used to communicate back to the webservice (env var: INSIGHTS_TOKEN_SECRET).")
-
-	flag.BoolVar(&enableCMReconciler, "enable-configmap-reconciler", true,
-		"Enable the configmap reconciler (env var: ENABLE_CONFIGMAP_RECONCILER).")
-
-	flag.BoolVar(&enableNSReconciler, "enable-namespace-reconciler", true,
-		"enable-namespace-reconciler (env var: ENABLE_NAMESPACE_RECONCILER).")
-
-	flag.BoolVar(&enableInsightDeferred, "enable-insights-deferred", false,
-		"Delete insights after certain time (env var: ENABLE_INSIGHTS_DEFERRED).")
-
-	flag.BoolVar(&enableWebservice, "enable-webservice", true,
-		"Enables json endpoint for writing insights data (env var: ENABLE_WEBSERVICE).")
-
-	flag.StringVar(&tokenTargetLabel, "token-target-label", "",
-		"Constrain webservice token generation to namespaces with this label (env var: TOKEN_TARGET_LABEL).")
-
-	flag.StringVar(&webservicePort, "webservice-port", "8888",
-		"Port on which we expose the JSON webservice (env var: WEBSERVICE_PORT).")
-
+	// CLI command and flags.
 	flag.BoolVar(&generateTokenOnly, "generate-token-only", false, "Generate a token and exit.")
-
 	flag.StringVar(&generateTokenOnlyNamespace, "generate-token-only-namespace", "", "Namespace for which to generate a token.")
-
 	flag.StringVar(&generateTokenOnlyEnvironmentId, "generate-token-only-environment-id", "", "EnvironmentName ID for which to generate a token.")
-
 	flag.StringVar(&generateTokenOnlyProjectName, "generate-token-only-project-name", "", "ProjectName name for which to generate a token.")
-
 	flag.StringVar(&generateTokenOnlyEnvironmentName, "generate-token-only-environment-name", "", "EnvironmentName name for which to generate a token.")
 
-	// If these two are set, we will post to Dependency Track post-process
-	flag.BoolVar(&enableDependencyTrackIntegration, "enable-dependency-track-integration", false, "Enable Dependency Track integration.")
-	flag.StringVar(&dependencyTrackApiEndpoint, "dependency-track-api-endpoint", "", "The endpoint for the Dependency Track API.")
-	flag.StringVar(&dependencyTrackApiKey, "dependency-track-api-key", "", "The API key for the Dependency Track API.")
-	flag.StringVar(&dependencyTrackRootProjectNameTemplate, "dependency-track-root-project-name-template", "{{ .ProjectName }}", "The template for the root project name in Dependency Track.")
-	flag.StringVar(&dependencyTrackParentProjectNameTemplate, "dependency-track-parent-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}", "The template for the parent project name in Dependency Track.")
-	flag.StringVar(&dependencyTrackProjectNameTemplate, "dependency-track-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}-{{ .ServiceName }}", "The template for the project name in Dependency Track.")
-	flag.StringVar(&dependencyTrackVersionTemplate, "dependency-track-version-template", "unset", "The template for the version in Dependency Track.")
-
+	// Automatically parse logging flags.
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
+
 	flag.Parse()
 
-	//Generate a token and exit if generateTokenOnly is set
+	// Generate a token and exit if generateTokenOnly is set.
 	if generateTokenOnly {
 		if generateTokenOnlyEnvironmentName == "" || generateTokenOnlyEnvironmentId == "" || generateTokenOnlyProjectName == "" || generateTokenOnlyNamespace == "" {
 			log.Fatal("generate-token-only requires all of generate-token-only-environment-name, generate-token-only-environment-id, generate-token-only-project-name and generate-token-only-namespace to be set")
@@ -230,12 +213,35 @@ func main() {
 		os.Exit(0)
 	}
 
-	//Grab overrides from environment where appropriate
+	/*
+	 * Env var overrides
+	 */
 
+	// Insights processing.
+	enableCMReconciler = variables.GetEnvBool("ENABLE_CONFIGMAP_RECONCILER", enableNSReconciler)
+	clearConfigmapCronSched = variables.GetEnv("CLEAR_CONFIGMAP_SCHED", clearConfigmapCronSched)
+	enableInsightDeferred = variables.GetEnvBool("ENABLE_INSIGHTS_DEFERRED", enableInsightDeferred)
+	if variables.GetEnv("BURN_AFTER_READING", "FALSE") == "TRUE" {
+		log.Printf("Burn-after-reading enabled via environment variable")
+		burnAfterReading = true
+	}
+
+	// Insights shipping: web service.
+	enableNSReconciler = variables.GetEnvBool("ENABLE_NAMESPACE_RECONCILER", enableNSReconciler)
+	enableWebservice = variables.GetEnvBool("ENABLE_WEBSERVICE", enableWebservice)
+	webservicePort = variables.GetEnv("WEBSERVICE_PORT", webservicePort)
+	insightsTokenSecret = variables.GetEnv("INSIGHTS_TOKEN_SECRET", insightsTokenSecret)
+	tokenTargetLabel = variables.GetEnv("TOKEN_TARGET_LABEL", tokenTargetLabel)
+
+	// Insights shipping: Dependency Track.
+	enableDependencyTrackIntegration = variables.GetEnvBool("ENABLE_DEPENDENCY_TRACK_INTEGRATION", enableDependencyTrackIntegration)
+	dependencyTrackApiEndpoint = variables.GetEnv("DEPENDENCY_TRACK_API_ENDPOINT", dependencyTrackApiEndpoint)
+	dependencyTrackApiKey = variables.GetEnv("DEPENDENCY_TRACK_API_KEY", dependencyTrackApiKey)
+
+	// RMQ env var overrides.
 	mqUser = variables.GetEnv("RABBITMQ_USERNAME", mqUser)
 	mqPass = variables.GetEnv("RABBITMQ_PASSWORD", mqPass)
 	mqHost = variables.GetEnv("RABBITMQ_ADDRESS", mqHost)
-	//rabbitReconnectRetryInterval = variables.GetEnv("RABBITMQ_RECONNECT_RETRY_INTERVAL", rabbitReconnectRetryInterval)
 	mqEnable = variables.GetEnvBool("RABBITMQ_ENABLED", mqEnable)
 	mqTLS = variables.GetEnvBool("RABBITMQ_TLS", mqTLS)
 	mqCACert = variables.GetEnv("RABBITMQ_CACERT", mqCACert)
@@ -243,24 +249,7 @@ func main() {
 	mqClientKey = variables.GetEnv("RABBITMQ_CLIENTKEY", mqClientKey)
 	mqVerify = variables.GetEnvBool("RABBITMQ_VERIFY", mqVerify)
 
-	insightsTokenSecret = variables.GetEnv("INSIGHTS_TOKEN_SECRET", insightsTokenSecret)
-	clearConfigmapCronSched = variables.GetEnv("CLEAR_CONFIGMAP_SCHED", clearConfigmapCronSched)
-	enableCMReconciler = variables.GetEnvBool("ENABLE_CONFIGMAP_RECONCILER", enableNSReconciler)
-	enableInsightDeferred = variables.GetEnvBool("ENABLE_INSIGHTS_DEFERRED", enableInsightDeferred)
-	enableNSReconciler = variables.GetEnvBool("ENABLE_NAMESPACE_RECONCILER", enableNSReconciler)
-	enableWebservice = variables.GetEnvBool("ENABLE_WEBSERVICE", enableWebservice)
-	tokenTargetLabel = variables.GetEnv("TOKEN_TARGET_LABEL", tokenTargetLabel)
-	webservicePort = variables.GetEnv("WEBSERVICE_PORT", webservicePort)
-	//Check burn after reading value from environment
-	if variables.GetEnv("BURN_AFTER_READING", "FALSE") == "TRUE" {
-		log.Printf("Burn-after-reading enabled via environment variable")
-		burnAfterReading = true
-	}
-	// Check if Dependency Track integration is enabled
-	enableDependencyTrackIntegration = variables.GetEnvBool("ENABLE_DEPENDENCY_TRACK_INTEGRATION", enableDependencyTrackIntegration)
-	dependencyTrackApiEndpoint = variables.GetEnv("DEPENDENCY_TRACK_API_ENDPOINT", dependencyTrackApiEndpoint)
-	dependencyTrackApiKey = variables.GetEnv("DEPENDENCY_TRACK_API_KEY", dependencyTrackApiKey)
-
+	// Configure RMQ.
 	brokerDSN := fmt.Sprintf("amqp://%s:%s@%s", mqUser, mqPass, mqHost)
 	if mqTLS {
 		verify := "verify_none"
@@ -278,6 +267,7 @@ func main() {
 			brokerDSN = fmt.Sprintf("%s&keyfile=%s", brokerDSN, mqClientKey)
 		}
 	}
+
 	mqConfig = mq.Config{
 		ReconnectDelay: time.Duration(rabbitReconnectRetryInterval) * time.Second,
 		Exchanges: mq.Exchanges{
@@ -319,8 +309,7 @@ func main() {
 		DSN: brokerDSN,
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
+	// Configure metrics server.
 	disableHTTP2 := func(c *tls.Config) {
 		setupLog.Info("disabling http/2")
 		c.NextProtos = []string{"http/1.1"}
@@ -342,6 +331,10 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
+	// Configure logging.
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Configure controller manager.
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -393,7 +386,6 @@ func main() {
 			})
 		}
 
-		// Set up the controller
 		if err = (&controllers.ConfigMapReconciler{
 			Client:           mgr.GetClient(),
 			Scheme:           mgr.GetScheme(),
@@ -458,6 +450,29 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func mqWriteObject(data []byte) error {
+	messageQ, err := mq.New(mqConfig)
+	if err != nil {
+		//TODO: Log useful data here ...
+		return err
+	}
+	defer messageQ.Close()
+
+	producer, err := messageQ.SyncProducer("lagoon-insights")
+	if err != nil {
+		//log.Error(err, "Unable to write to message broker")
+		return err
+	}
+
+	err = producer.Produce(data)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func startBurnAfterReadingCron(mgr manager.Manager) {

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -52,15 +51,7 @@ type ConfigMapReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=configmaps/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ConfigMap object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
+// Gathers insights related Config Maps and ships them to configured endpoints.
 func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
@@ -115,7 +106,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// We reject any type that isn't either sbom or inspect to restrict outgoing types
 	if insightsType != internal.InsightsTypeSBOM && insightsType != internal.InsightsTypeInspect {
 		//// we mark this configMap as bad, and log an error
-		err := errors.New(fmt.Sprintf("insightsType '%v' unrecognized - rejecting configMap", insightsType))
+		err := fmt.Errorf("insightsType '%v' unrecognized - rejecting configMap", insightsType)
 		log.Error(err, err.Error())
 	} else {
 		// Here we attempt to process types using the new name structure

--- a/internal/controller/namespace_controller.go
+++ b/internal/controller/namespace_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,15 +47,7 @@ const insightsTokenLabel = "lagoon.sh/insights-token"
 //+kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=namespaces/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Namespace object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
+// Injects tokens that can be used to post insights to the web service.
 func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 

--- a/internal/postprocess/dependency_track/custom_postprocess.go
+++ b/internal/postprocess/dependency_track/custom_postprocess.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"lagoon.sh/insights-remote/internal"
+	"lagoon.sh/insights-remote/internal/postprocess"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,6 +17,29 @@ import (
 type CustomPostProcess struct {
 	Client    client.Client
 	Templates Templates
+}
+
+func NewCustomPostProcessor(
+	enableDependencyTrackIntegration bool,
+	client client.Client,
+	dependencyTrackRootProjectNameTemplate string,
+	dependencyTrackParentProjectNameTemplate string,
+	dependencyTrackProjectNameTemplate string,
+	dependencyTrackVersionTemplate string,
+) postprocess.PostProcessor {
+	if !enableDependencyTrackIntegration {
+		return nil
+	}
+
+	return &CustomPostProcess{
+		Client: client,
+		Templates: newTemplate(
+			dependencyTrackRootProjectNameTemplate,
+			dependencyTrackParentProjectNameTemplate,
+			dependencyTrackProjectNameTemplate,
+			dependencyTrackVersionTemplate,
+		),
+	}
 }
 
 func (d *CustomPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {

--- a/internal/postprocess/dependency_track/default_postprocess.go
+++ b/internal/postprocess/dependency_track/default_postprocess.go
@@ -3,6 +3,7 @@ package deptrack
 import (
 	dtrack "github.com/DependencyTrack/client-go"
 	"lagoon.sh/insights-remote/internal"
+	"lagoon.sh/insights-remote/internal/postprocess"
 )
 
 // DefaultPostProcess will send insights for all namespaces to a central Dependency Track instance.
@@ -10,6 +11,35 @@ type DefaultPostProcess struct {
 	ApiEndpoint string
 	ApiKey      string
 	Templates   Templates
+}
+
+func NewDefaultPostProcessor(
+	enableDependencyTrackIntegration bool,
+	dependencyTrackApiEndpoint string,
+	dependencyTrackApiKey string,
+	dependencyTrackRootProjectNameTemplate string,
+	dependencyTrackParentProjectNameTemplate string,
+	dependencyTrackProjectNameTemplate string,
+	dependencyTrackVersionTemplate string,
+) postprocess.PostProcessor {
+	if !enableDependencyTrackIntegration {
+		return nil
+	}
+
+	if dependencyTrackApiEndpoint == "" || dependencyTrackApiKey == "" {
+		return nil
+	}
+
+	return &DefaultPostProcess{
+		ApiEndpoint: dependencyTrackApiEndpoint,
+		ApiKey:      dependencyTrackApiKey,
+		Templates: newTemplate(
+			dependencyTrackRootProjectNameTemplate,
+			dependencyTrackParentProjectNameTemplate,
+			dependencyTrackProjectNameTemplate,
+			dependencyTrackVersionTemplate,
+		),
+	}
 }
 
 func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage) error {

--- a/internal/postprocess/dependency_track/dependencyTrack.go
+++ b/internal/postprocess/dependency_track/dependencyTrack.go
@@ -29,6 +29,27 @@ type writeInfo struct {
 	ProjectVersion     string
 }
 
+func newTemplate(
+	dependencyTrackRootProjectNameTemplate string,
+	dependencyTrackParentProjectNameTemplate string,
+	dependencyTrackProjectNameTemplate string,
+	dependencyTrackVersionTemplate string,
+) Templates {
+	dtTemplates := []string{}
+	if dependencyTrackParentProjectNameTemplate != "" {
+		if dependencyTrackRootProjectNameTemplate != "" {
+			dtTemplates = append(dtTemplates, dependencyTrackRootProjectNameTemplate)
+		}
+		dtTemplates = append(dtTemplates, dependencyTrackParentProjectNameTemplate)
+	}
+
+	return Templates{
+		ParentProjectNameTemplates: dtTemplates,
+		ProjectNameTemplate:        dependencyTrackProjectNameTemplate,
+		VersionTemplate:            dependencyTrackVersionTemplate,
+	}
+}
+
 // This is a helper function to process a template string given a dependencyTrackWriteInfo struct
 func processTemplate(templateString string, info interface{}) (string, error) {
 	tmpl, err := template.New("templateString").Parse(templateString)

--- a/internal/postprocess/insights_core/insights_core.go
+++ b/internal/postprocess/insights_core/insights_core.go
@@ -28,10 +28,8 @@ func NewPostProcessor(
 }
 
 func (p *PostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
-	if enableInsightsCoreIntegration, exists := message.Annotations["core.insights.lagoon.sh/enabled"]; exists {
-		if enableInsightsCoreIntegration == "false" {
-			return nil
-		}
+	if message.Annotations["core.insights.lagoon.sh/enabled"] != "true" {
+		return nil
 	}
 
 	marshalledData, err := json.Marshal(message)

--- a/internal/postprocess/insights_core/insights_core.go
+++ b/internal/postprocess/insights_core/insights_core.go
@@ -1,0 +1,48 @@
+package insightcore
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"lagoon.sh/insights-remote/internal"
+	"lagoon.sh/insights-remote/internal/postprocess"
+)
+
+// PostProcess will send insights for all namespaces to Lagoon core insights-handler.
+type PostProcess struct {
+	MessageQWriter func(data []byte) error
+}
+
+func NewPostProcessor(
+	mqEnable bool,
+	mqWriteObject func(data []byte) error,
+) postprocess.PostProcessor {
+	// Check if RabbitMQ is disabled.
+	if !mqEnable {
+		return nil
+	}
+
+	return &PostProcess{
+		MessageQWriter: mqWriteObject,
+	}
+}
+
+func (p *PostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
+	if enableInsightsCoreIntegration, exists := message.Annotations["core.insights.lagoon.sh/enabled"]; exists {
+		if enableInsightsCoreIntegration == "false" {
+			return nil
+		}
+	}
+
+	marshalledData, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("unable to marshall config data: %w", err)
+	}
+
+	err = p.MessageQWriter(marshalledData)
+	if err != nil {
+		return fmt.Errorf("unable to write to message broker: %w", err)
+	}
+
+	return nil
+}

--- a/internal/postprocess/postprocess.go
+++ b/internal/postprocess/postprocess.go
@@ -5,10 +5,6 @@ import (
 )
 
 type PostProcessor interface {
-	// PostProcess processes insights for 3rd party tools. Must be idempotent.
+	// PostProcess processes insights. Must be idempotent.
 	PostProcess(message internal.LagoonInsightsMessage) error
-}
-
-type PostProcessors struct {
-	PostProcessors []PostProcessor
 }


### PR DESCRIPTION
Moves the shipping of insights to Lagoon Core to a post-processor and adds a feature flag to allow it to be disabled.