### PR TITLE
Feature post insights scan rebase

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -227,22 +227,10 @@ func main() {
 	 * Env var overrides
 	 */
 
-	// Message queue.
-	mqUser = variables.GetEnv("RABBITMQ_USERNAME", mqUser)
-	mqPass = variables.GetEnv("RABBITMQ_PASSWORD", mqPass)
-	mqHost = variables.GetEnv("RABBITMQ_ADDRESS", mqHost)
-	mqPort = variables.GetEnv("RABBITMQ_PORT", mqPort)
-	mqEnable = variables.GetEnvBool("RABBITMQ_ENABLED", mqEnable)
-
 	// Insights processing.
-	insightsTokenSecret = variables.GetEnv("INSIGHTS_TOKEN_SECRET", insightsTokenSecret)
 	clearConfigmapCronSched = variables.GetEnv("CLEAR_CONFIGMAP_SCHED", clearConfigmapCronSched)
 	enableCMReconciler = variables.GetEnvBool("ENABLE_CONFIGMAP_RECONCILER", enableNSReconciler)
 	enableInsightDeferred = variables.GetEnvBool("ENABLE_INSIGHTS_DEFERRED", enableInsightDeferred)
-	enableNSReconciler = variables.GetEnvBool("ENABLE_NAMESPACE_RECONCILER", enableNSReconciler)
-	enableWebservice = variables.GetEnvBool("ENABLE_WEBSERVICE", enableWebservice)
-	tokenTargetLabel = variables.GetEnv("TOKEN_TARGET_LABEL", tokenTargetLabel)
-	webservicePort = variables.GetEnv("WEBSERVICE_PORT", webservicePort)
 	enableBuildScanning = variables.GetEnvBool("ENABLE_BUILD_SCANNING", enableBuildScanning)
 	buildScannerImage = variables.GetEnv("BUILD_SCANNER_IMAGE", buildScannerImage)
 
@@ -268,6 +256,7 @@ func main() {
 	mqUser = variables.GetEnv("RABBITMQ_USERNAME", mqUser)
 	mqPass = variables.GetEnv("RABBITMQ_PASSWORD", mqPass)
 	mqHost = variables.GetEnv("RABBITMQ_ADDRESS", mqHost)
+	mqPort = variables.GetEnv("RABBITMQ_PORT", mqPort)
 	mqEnable = variables.GetEnvBool("RABBITMQ_ENABLED", mqEnable)
 	mqTLS = variables.GetEnvBool("RABBITMQ_TLS", mqTLS)
 	mqCACert = variables.GetEnv("RABBITMQ_CACERT", mqCACert)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,7 +66,6 @@ var (
 	mqUser                                   string
 	mqPass                                   string
 	mqHost                                   string
-	mqPort                                   string
 	mqTLS                                    bool
 	mqVerify                                 bool
 	mqCACert                                 string
@@ -256,7 +255,6 @@ func main() {
 	mqUser = variables.GetEnv("RABBITMQ_USERNAME", mqUser)
 	mqPass = variables.GetEnv("RABBITMQ_PASSWORD", mqPass)
 	mqHost = variables.GetEnv("RABBITMQ_ADDRESS", mqHost)
-	mqPort = variables.GetEnv("RABBITMQ_PORT", mqPort)
 	mqEnable = variables.GetEnvBool("RABBITMQ_ENABLED", mqEnable)
 	mqTLS = variables.GetEnvBool("RABBITMQ_TLS", mqTLS)
 	mqCACert = variables.GetEnv("RABBITMQ_CACERT", mqCACert)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -193,7 +193,7 @@ func main() {
 	flag.BoolVar(&enableBuildScanning, "enable-build-scanner", true,
 		"Enables scanning of build images on successful builds (env var: ENABLE_BUILD_SCANNING).")
 
-	flag.StringVar(&buildScannerImage, "build-scanner-image", "imagecache.amazeeio.cloud/bomoko/insights-scan:latest",
+	flag.StringVar(&buildScannerImage, "build-scanner-image", "uselagoon/insights-scanner:latest",
 		"Specifies an image to be used by the build-scanning process (env var: BUILD_SCANNER_IMAGE")
 
 	// Automatically parse logging flags.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -412,6 +412,20 @@ func main() {
 		log.Printf("Namespace reconciler disabled - skipping")
 	}
 
+	enableScanner := true
+	if enableScanner {
+		if err = (&controllers.BuildReconciler{
+			Client:            mgr.GetClient(),
+			Scheme:            mgr.GetScheme(),
+			InsightsJWTSecret: insightsTokenSecret,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create build reconciler controller", "controller", "Namespace")
+			os.Exit(1)
+		}
+	} else {
+		log.Printf("Build reconciler disabled - skipping")
+	}
+
 	if enableWebservice {
 		log.Println("Enabling JSON endpoint ...")
 		startInsightsEndpoint(mgr)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -438,6 +438,7 @@ func main() {
 	}
 
 	if enableBuildScanning {
+		log.Printf("Build reconciler enabled - starting")
 		if err = (&controllers.BuildReconciler{
 			Client:            mgr.GetClient(),
 			Scheme:            mgr.GetScheme(),

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,10 +5,49 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - create
   - delete
@@ -30,6 +69,10 @@ rules:
   - configmaps/status
   - namespaces/status
   verbs:
+  - create
+  - delete
   - get
+  - list
   - patch
   - update
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,17 +5,11 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
+  - pods
+  - secrets
   verbs:
   - create
   - delete
@@ -33,46 +27,10 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
+  - apps
   resources:
-  - pods
+  - deployments
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/finalizers
-  - namespaces/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  - namespaces/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch

--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.8.0 // indirect
-	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,12 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
 github.com/gin-gonic/gin v1.10.1/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
+github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
+github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=
+github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
+github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01KS3zGE=
+github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -491,6 +497,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
@@ -665,6 +673,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
+github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -718,6 +728,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
+github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -731,6 +743,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
+github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
@@ -798,8 +812,6 @@ github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1ls
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
-github.com/onsi/ginkgo/v2 v2.25.3 h1:Ty8+Yi/ayDAGtk4XxmmfUy4GabvM+MegeB4cDLRi6nw=
-github.com/onsi/ginkgo/v2 v2.25.3/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/ginkgo/v2 v2.27.3 h1:ICsZJ8JoYafeXFFlFAG75a7CxMsJHwgKwtO+82SE9L8=
 github.com/onsi/ginkgo/v2 v2.27.3/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -869,8 +881,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
-github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -1004,6 +1014,14 @@ github.com/testcontainers/testcontainers-go v0.22.0 h1:hOK4NzNu82VZcKEB1aP9LO1xY
 github.com/testcontainers/testcontainers-go v0.22.0/go.mod h1:k0YiPa26xJCRUbUkYqy5rY6NGvSbVCeUBXCvucscBR4=
 github.com/tiago4orion/conjure v0.0.0-20150908101743-93cb30b9d218 h1:tOESt7J50fPC9NqR0VdU1Zxk2zo5QYH70ap5TsU1bt4=
 github.com/tiago4orion/conjure v0.0.0-20150908101743-93cb30b9d218/go.mod h1:GQei++1WClbEC7AN1B9ipY1jCjzllM/7UNg0okAh/Z4=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1109,8 +1127,6 @@ go.opentelemetry.io/proto/otlp v1.8.0/go.mod h1:tIeYOeNBU4cvmPqpaji1P+KbB4Oloai8
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
-go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -83,6 +83,7 @@ func successfulBuildPodsPredicate() predicate.Predicate {
 
 			//TODO: need the logic here to find the appropriate types
 			// that is, successful and build pods
+			fmt.Printf("Got here")
 			labels := event.ObjectNew.GetLabels()
 			_, err := getValueFromMap(labels, "lagoon.sh/buildName")
 			fmt.Printf("A")

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -45,10 +45,9 @@ const insightsBuildPodScannedLabel = "insights.lagoon.sh/scanned"
 const insightsScanPodLabel = "insights.lagoon.sh/scan-status"
 const dockerhost = "docker-host.lagoon.svc" //TODO in future versions this will be read from the build CRD
 
-//+kubebuilder:rbac:groups=core,resources=deployments,verbs=get;list
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
 
 // Reconcile is part of the Kubebuilder machinery - it kicks off when we find a build pod in the correct
 // state for scanning - i.e. whenever there's a successful build.

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -83,22 +83,19 @@ func successfulBuildPodsPredicate() predicate.Predicate {
 
 			//TODO: need the logic here to find the appropriate types
 			// that is, successful and build pods
-			fmt.Printf("Got here")
+
 			labels := event.ObjectNew.GetLabels()
 			_, err := getValueFromMap(labels, "lagoon.sh/buildName")
-			fmt.Printf("A")
 			if err != nil {
-				fmt.Printf("Ae")
 				return false //this isn't a build pod
 			}
-			fmt.Printf("B")
+
 			val, err := getValueFromMap(labels, insightsScannedLabel)
-			if err != nil || val == "false" {
-				fmt.Printf("Be")
+			if err == nil && val == "false" {
 				return false
 			}
-			fmt.Printf("C")
 			return true
+
 		},
 		GenericFunc: func(genericEvent event.GenericEvent) bool {
 			return false

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -18,14 +18,18 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"strings"
 )
 
 // BuildReconciler reconciles a Build Pod object
@@ -33,9 +37,11 @@ type BuildReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	InsightsJWTSecret string
+	//ScanImageName     string // TODO: make this something that's passed as an argument
 }
 
 const insightsScannedLabel = "insights.lagoon.sh/scanned"
+const scanImageName = "imagecache.amazeeio.cloud/bomoko/insights-scan:latest"
 
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
@@ -54,6 +60,7 @@ func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	log := log.FromContext(ctx)
 
 	var buildPod corev1.Pod
+
 	if err := r.Get(ctx, req.NamespacedName, &buildPod); err != nil {
 		log.Error(err, "Unable to load Pod")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -61,11 +68,39 @@ func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// we check the build pod itself to see if its status is good
 	if buildPod.Status.Phase == corev1.PodSucceeded {
+
+		imageList, err := r.scanDeployments(ctx, req, buildPod.Namespace)
+		if err != nil {
+			log.Error(err, "Unable to scan deployments")
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+
+		// now we generate the pod spec we'd like to deploy
+		podspec, err := generateScanPodSpec(imageList, buildPod.Name, buildPod.Namespace)
+		if err != nil {
+			log.Error(err, "Unable to generate podspec")
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+
+		// Remove any existing pods
+		err = r.killExistingScans(ctx, scannerNameFromBuildname(buildPod.Name), buildPod.Namespace)
+		if err != nil {
+			log.Error(err, "Unable to remove existing scan pods")
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+
+		// Deploy scan pod
+		err = r.Client.Create(ctx, podspec)
+		if err != nil {
+			log.Error(err, "Couldn't create pod")
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+
 		labels := buildPod.GetLabels()
 		// Let's label the pod as having been seen
 		labels[insightsScannedLabel] = "true"
 		buildPod.SetLabels(labels)
-		err := r.Update(ctx, &buildPod)
+		err = r.Update(ctx, &buildPod)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to update pod labels: %v", req.NamespacedName.String()))
 			return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -73,6 +108,123 @@ func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// scanDeployments will look at all the deployments in a namespace and
+// if they're labeled correctly, bundle their images into a single scan
+func (r *BuildReconciler) scanDeployments(ctx context.Context, req ctrl.Request, namespace string) ([]string, error) {
+
+	deploymentList := &v1.DeploymentList{}
+	err := r.List(ctx, deploymentList, client.InNamespace(namespace))
+	if err != nil {
+		return []string{}, err
+	}
+	var imageList []string
+	for _, d := range deploymentList.Items {
+		log.Log.Info(fmt.Sprintf("Found deployment '%v' in namespace '%v'\n", d.Name, namespace))
+
+		// TODO so we want to filter deployments based on the appropriate labels
+
+		// Let's get a list of all the images involved
+		for _, i := range d.Spec.Template.Spec.Containers {
+			imageList = append(imageList, i.Image)
+			log.Log.Info(fmt.Sprintf("    Found image: %v\n", i.Image))
+		}
+	}
+
+	return imageList, nil
+}
+
+func generateScanPodSpec(images []string, buildName string, namespace string) (*corev1.Pod, error) {
+
+	if len(images) == 0 {
+		return nil, errors.New("No images to scan")
+	}
+
+	insightScanImages := strings.Join(images, ",")
+
+	// Define PodSpec
+
+	podSpec := &corev1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: namespace,
+			Name:      scannerNameFromBuildname(buildName),
+			Labels:    imageScanPodLabels(),
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "lagoon-deployer",
+			Containers: []corev1.Container{
+				{
+					Name:  "scanner",
+					Image: scanImageName,
+					Env: []corev1.EnvVar{
+						{
+							Name:  "INSIGHT_SCAN_IMAGES",
+							Value: insightScanImages,
+						},
+						{
+							Name:  "NAMESPACE",
+							Value: namespace,
+						},
+					},
+					ImagePullPolicy: "Always",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "lagoon-internal-registry-secret",
+							MountPath: "/home/.docker/",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			RestartPolicy: "Never",
+			Volumes: []corev1.Volume{ // Here we have to mount the
+				{
+					Name: "lagoon-internal-registry-secret",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "lagoon-internal-registry-secret",
+							Items: []corev1.KeyToPath{
+								{Key: ".dockerconfigjson", Path: "config.json"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return podSpec, nil
+}
+
+func (r *BuildReconciler) killExistingScans(ctx context.Context, newScannerName string, namespace string) error {
+	// Find pods in namespace with the image scan pod labels
+
+	podlist := &corev1.PodList{}
+	//ls := client.MatchingLabels{"insights.lagoon.sh/imagescanner": "scanning"}
+	ls := client.MatchingLabels(imageScanPodLabels())
+	ns := client.InNamespace(namespace)
+	err := r.Client.List(ctx, podlist, ns, ls)
+	if err != nil {
+		return err
+	}
+	for _, i := range podlist.Items {
+		if i.Name != newScannerName { // Then we have a rogue pod
+			//r.Client.Delete(ctx, &i)
+			log.Log.Info(fmt.Sprintf("Going to delete pod: %v", i.Name))
+		}
+	}
+	return nil
+}
+
+func imageScanPodLabels() map[string]string {
+	return map[string]string{
+		"insights.lagoon.sh/imagescanner": "scanning",
+		"lagoon.sh/buildName":             "notabuild",
+	}
+}
+
+func scannerNameFromBuildname(buildName string) string {
+	return fmt.Sprintf("insights-scanner-%v", buildName)
 }
 
 func successfulBuildPodsPredicate() predicate.Predicate {
@@ -84,14 +236,27 @@ func successfulBuildPodsPredicate() predicate.Predicate {
 			//TODO: need the logic here to find the appropriate types
 			// that is, successful and build pods
 
+			// TODO: remove when happy with process - and we want it to run across everything
+			if event.ObjectNew.GetNamespace() != "test6-drupal-example-simple-test1copy" {
+				return false
+			}
+
 			labels := event.ObjectNew.GetLabels()
 			_, err := getValueFromMap(labels, "lagoon.sh/buildName")
 			if err != nil {
+				log.Log.Info(fmt.Sprintf("Not a build pod, skipping : %v", event.ObjectNew.GetName()))
+				return false //this isn't a build pod
+			}
+
+			_, err = getValueFromMap(labels, "insights.lagoon.sh/imagescanner")
+			if err == nil {
+				log.Log.Info(fmt.Sprintf("Found a scanner pod, skipping : %v", event.ObjectNew.GetName()))
 				return false //this isn't a build pod
 			}
 
 			val, err := getValueFromMap(labels, insightsScannedLabel)
-			if err == nil && val == "false" {
+			if err == nil {
+				log.Log.Info(fmt.Sprintf("Build pod already scanned, skipping : %v - value: %v", event.ObjectNew.GetName(), val))
 				return false
 			}
 			return true
@@ -102,64 +267,6 @@ func successfulBuildPodsPredicate() predicate.Predicate {
 		},
 	}
 }
-
-//
-//func activeNamespacePredicate(tokenTargetLabel string) predicate.Predicate {
-//	return predicate.Funcs{
-//		CreateFunc: func(event event.CreateEvent) bool {
-//			labels := event.Object.GetLabels()
-//			_, err := getValueFromMap(labels, "lagoon.sh/environmentId")
-//			if err != nil {
-//				return false
-//			}
-//			_, err = getValueFromMap(labels, "lagoon.sh/project")
-//			if err != nil {
-//				return false
-//			}
-//			_, err = getValueFromMap(labels, "lagoon.sh/environment")
-//			if err != nil {
-//				return false
-//			}
-//
-//			if tokenTargetLabel != "" {
-//				_, err = getValueFromMap(labels, tokenTargetLabel)
-//				if err != nil {
-//					return false
-//				}
-//			}
-//
-//			return true
-//		},
-//		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
-//			return false
-//		},
-//		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-//			labels := updateEvent.ObjectNew.GetLabels()
-//			_, err := getValueFromMap(labels, "lagoon.sh/environmentId")
-//			if err != nil {
-//				return false
-//			}
-//			_, err = getValueFromMap(labels, "lagoon.sh/project")
-//			if err != nil {
-//				return false
-//			}
-//			_, err = getValueFromMap(labels, "lagoon.sh/environment")
-//			if err != nil {
-//				return false
-//			}
-//			if tokenTargetLabel != "" {
-//				_, err = getValueFromMap(labels, tokenTargetLabel)
-//				if err != nil {
-//					return false
-//				}
-//			}
-//			return true
-//		},
-//		GenericFunc: func(genericEvent event.GenericEvent) bool {
-//			return false
-//		},
-//	}
-//}
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BuildReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -44,9 +44,10 @@ type BuildReconciler struct {
 const insightsScannedLabel = "insights.lagoon.sh/scanned"
 const dockerhost = "docker-host.lagoon.svc" //TODO in future versions this will be read from the build CRD
 
-//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=core,resources=namespaces/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=deployments,verbs=get;list
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list
 
 // Reconcile is part of the Kubebuilder machinery - it kicks off when we find a build pod in the correct
 // state for scanning - i.e. whenever there's a successful build.

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -44,6 +44,7 @@ type BuildReconciler struct {
 
 const insightsBuildPodScannedLabel = "insights.lagoon.sh/scanned"
 const insightsScanPodLabel = "insights.lagoon.sh/scan-status"
+const insightImageScannerPodLabel = "insights.lagoon.sh/imagescanner"
 const dockerhost = "docker-host.lagoon.svc" //TODO in future versions this will be read from the build CRD
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
@@ -89,7 +90,7 @@ func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 
 		buildDockerhost := extractDockerHost(&buildPod, dockerhost)
-		
+
 		if buildDockerhost == dockerhost {
 			logger.Info("No dockerhost.lagoon.sh/name annotation found on build pod, using default")
 		}
@@ -143,13 +144,13 @@ func getNamespaceLabel(labels map[string]string, key string) (string, error) {
 // extractDockerHost extracts the dockerhost from build pod annotations with fallback to default
 func extractDockerHost(buildPod *corev1.Pod, defaultDockerHost string) string {
 	const dockerHostAnnotationKey = "dockerhost.lagoon.sh/name"
-	
+
 	if buildPod.Annotations != nil {
 		if val, ok := buildPod.Annotations[dockerHostAnnotationKey]; ok {
 			return val
 		}
 	}
-	
+
 	return defaultDockerHost
 }
 
@@ -279,7 +280,8 @@ func (r *BuildReconciler) killExistingScans(ctx context.Context, newScannerName 
 
 func imageScanPodLabels() map[string]string {
 	return map[string]string{
-		insightsScanPodLabel: "scanning",
+		insightsScanPodLabel:        "scanning",
+		insightImageScannerPodLabel: "true",
 	}
 }
 

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -278,11 +278,6 @@ func successfulBuildPodsPredicate() predicate.Predicate {
 			//TODO: need the logic here to find the appropriate types
 			// that is, successful and build pods
 
-			// TODO: remove when happy with process - and we want it to run across everything
-			if event.ObjectNew.GetNamespace() != "test6-drupal-example-simple-test1copy" {
-				return false
-			}
-
 			labels := event.ObjectNew.GetLabels()
 			_, err := getValueFromMap(labels, "lagoon.sh/buildName")
 			if err != nil {

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -85,13 +85,18 @@ func successfulBuildPodsPredicate() predicate.Predicate {
 			// that is, successful and build pods
 			labels := event.ObjectNew.GetLabels()
 			_, err := getValueFromMap(labels, "lagoon.sh/buildName")
+			fmt.Printf("A")
 			if err != nil {
+				fmt.Printf("Ae")
 				return false //this isn't a build pod
 			}
+			fmt.Printf("B")
 			val, err := getValueFromMap(labels, insightsScannedLabel)
 			if err != nil || val == "false" {
+				fmt.Printf("Be")
 				return false
 			}
+			fmt.Printf("C")
 			return true
 		},
 		GenericFunc: func(genericEvent event.GenericEvent) bool {

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// BuildReconciler reconciles a Build Pod object
+type BuildReconciler struct {
+	client.Client
+	Scheme            *runtime.Scheme
+	InsightsJWTSecret string
+}
+
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=core,resources=namespaces/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Namespace object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
+func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	var buildPod corev1.Pod
+	if err := r.Get(ctx, req.NamespacedName, &buildPod); err != nil {
+		log.Error(err, "Unable to load Pod")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	fmt.Println(buildPod)
+
+	return ctrl.Result{}, nil
+}
+
+func successfulBuildPodsPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool { return false },
+		DeleteFunc: func(event event.DeleteEvent) bool { return false },
+		UpdateFunc: func(event event.UpdateEvent) bool {
+
+			//TODO: need the logic here to find the appropriate types
+			// that is, successful and build pods
+			return true
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+//
+//func activeNamespacePredicate(tokenTargetLabel string) predicate.Predicate {
+//	return predicate.Funcs{
+//		CreateFunc: func(event event.CreateEvent) bool {
+//			labels := event.Object.GetLabels()
+//			_, err := getValueFromMap(labels, "lagoon.sh/environmentId")
+//			if err != nil {
+//				return false
+//			}
+//			_, err = getValueFromMap(labels, "lagoon.sh/project")
+//			if err != nil {
+//				return false
+//			}
+//			_, err = getValueFromMap(labels, "lagoon.sh/environment")
+//			if err != nil {
+//				return false
+//			}
+//
+//			if tokenTargetLabel != "" {
+//				_, err = getValueFromMap(labels, tokenTargetLabel)
+//				if err != nil {
+//					return false
+//				}
+//			}
+//
+//			return true
+//		},
+//		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+//			return false
+//		},
+//		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+//			labels := updateEvent.ObjectNew.GetLabels()
+//			_, err := getValueFromMap(labels, "lagoon.sh/environmentId")
+//			if err != nil {
+//				return false
+//			}
+//			_, err = getValueFromMap(labels, "lagoon.sh/project")
+//			if err != nil {
+//				return false
+//			}
+//			_, err = getValueFromMap(labels, "lagoon.sh/environment")
+//			if err != nil {
+//				return false
+//			}
+//			if tokenTargetLabel != "" {
+//				_, err = getValueFromMap(labels, tokenTargetLabel)
+//				if err != nil {
+//					return false
+//				}
+//			}
+//			return true
+//		},
+//		GenericFunc: func(genericEvent event.GenericEvent) bool {
+//			return false
+//		},
+//	}
+//}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *BuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithEventFilter(successfulBuildPodsPredicate()).
+		Complete(r)
+}

--- a/internal/controller/build_controller_test.go
+++ b/internal/controller/build_controller_test.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_generateScanPodSpec(t *testing.T) {
@@ -12,6 +14,7 @@ func Test_generateScanPodSpec(t *testing.T) {
 		images    []string
 		buildName string
 		namespace string
+		buildPod  *corev1.Pod
 	}
 	tests := []struct {
 		name    string
@@ -20,16 +23,39 @@ func Test_generateScanPodSpec(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "No images",
-			args:    args{images: nil, namespace: "testns", buildName: "buildnamehere"},
+			name: "No images to scan",
+			args: args{
+				images:   nil,
+				buildPod: &corev1.Pod{},
+			},
 			wantErr: true,
 		},
 		{
-			name: "FoundImages",
+			name: "Basic images to scan",
 			args: args{
-				images:    []string{"image1", "image2"},
-				namespace: "testns",
-				buildName: "buildnamehere",
+				images: []string{"image1", "image2"},
+				buildPod: &corev1.Pod{
+					ObjectMeta: v12.ObjectMeta{
+						Namespace: "testns",
+						Name:      "buildnamehere",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Env: []corev1.EnvVar{
+									{
+										Name:  "PROJECT",
+										Value: "projectName",
+									},
+									{
+										Name:  "ENVIRONMENT",
+										Value: "environmentName",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			want: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
@@ -53,6 +79,118 @@ func Test_generateScanPodSpec(t *testing.T) {
 									Value: "testns",
 								},
 								{
+									Name:  "DOCKER_HOST",
+									Value: defaultDockerhost,
+								},
+								{
+									Name:  "PROJECT",
+									Value: "projectName",
+								},
+								{
+									Name:  "ENVIRONMENT",
+									Value: "environmentName",
+								},
+							},
+							ImagePullPolicy: "Always",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "lagoon-internal-registry-secret",
+									MountPath: "/home/.docker/",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "lagoon-internal-registry-secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "lagoon-internal-registry-secret",
+									Items: []corev1.KeyToPath{
+										{Key: ".dockerconfigjson", Path: "config.json"},
+									},
+								},
+							},
+						},
+					},
+					RestartPolicy: "Never",
+				},
+			},
+		},
+		{
+			name: "Copy build pod env vars",
+			args: args{
+				images: []string{"image1", "image2"},
+				buildPod: &corev1.Pod{
+					ObjectMeta: v12.ObjectMeta{
+						Namespace: "testns",
+						Name:      "buildnamehere",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Env: []corev1.EnvVar{
+									{
+										Name:  "PROJECT",
+										Value: "projectName",
+									},
+									{
+										Name:  "ENVIRONMENT",
+										Value: "environmentName",
+									},
+									{
+										Name:  "ENVIRONMENT_ID",
+										Value: "10",
+									},
+									{
+										Name:  "LAGOON_ENVIRONMENT_VARIABLES",
+										Value: "lagoonEnvironmentVariables",
+									},
+									{
+										Name:  "LAGOON_FEATURE_FLAG_TEST",
+										Value: "lagoonFeatureFlagTest",
+									},
+									{
+										Name:  "LAGOON_FEATURE_FLAG_INSIGHTS",
+										Value: "lagoonFeatureFlagInsights",
+									},
+									{
+										Name:  "LAGOON_FEATURE_FLAG_",
+										Value: "lagoonFeatureFlag",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "testns",
+					Name:      scannerNameFromBuildname("buildnamehere"),
+					Labels:    imageScanPodLabels(),
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "lagoon-deployer",
+					Containers: []corev1.Container{
+						{
+							Name:  "scanner",
+							Image: "scanImageName",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "INSIGHT_SCAN_IMAGES",
+									Value: "image1,image2",
+								},
+								{
+									Name:  "NAMESPACE",
+									Value: "testns",
+								},
+								{
+									Name:  "DOCKER_HOST",
+									Value: defaultDockerhost,
+								},
+								{
 									Name:  "PROJECT",
 									Value: "projectName",
 								},
@@ -61,8 +199,16 @@ func Test_generateScanPodSpec(t *testing.T) {
 									Value: "environmentName",
 								},
 								{
-									Name:  "DOCKER_HOST",
-									Value: dockerhost,
+									Name:  "LAGOON_ENVIRONMENT_VARIABLES",
+									Value: "lagoonEnvironmentVariables",
+								},
+								{
+									Name:  "LAGOON_FEATURE_FLAG_TEST",
+									Value: "lagoonFeatureFlagTest",
+								},
+								{
+									Name:  "LAGOON_FEATURE_FLAG_INSIGHTS",
+									Value: "lagoonFeatureFlagInsights",
 								},
 							},
 							ImagePullPolicy: "Always",
@@ -95,7 +241,7 @@ func Test_generateScanPodSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateScanPodSpec(tt.args.images, "scanImageName", tt.args.buildName, tt.args.namespace, "projectName", "environmentName", dockerhost)
+			got, err := generateScanPodSpec(tt.args.buildPod, tt.args.images, "scanImageName", defaultDockerhost)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generateScanPodSpec() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -113,6 +259,7 @@ func Test_extractDockerHost(t *testing.T) {
 		buildPod          *corev1.Pod
 		defaultDockerHost string
 		want              string
+		wantErr           bool
 	}{
 		{
 			name: "Pod with dockerhost annotation",
@@ -125,8 +272,8 @@ func Test_extractDockerHost(t *testing.T) {
 					},
 				},
 			},
-			defaultDockerHost: "docker-host.lagoon.svc",
-			want:              "custom-docker-host.svc",
+			want:    "custom-docker-host.svc",
+			wantErr: false,
 		},
 		{
 			name: "Pod without dockerhost annotation",
@@ -139,8 +286,8 @@ func Test_extractDockerHost(t *testing.T) {
 					},
 				},
 			},
-			defaultDockerHost: "docker-host.lagoon.svc",
-			want:              "docker-host.lagoon.svc",
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name: "Pod with nil annotations",
@@ -151,8 +298,8 @@ func Test_extractDockerHost(t *testing.T) {
 					Annotations: nil,
 				},
 			},
-			defaultDockerHost: "docker-host.lagoon.svc",
-			want:              "docker-host.lagoon.svc",
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name: "Pod with empty annotations",
@@ -163,8 +310,8 @@ func Test_extractDockerHost(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
-			defaultDockerHost: "docker-host.lagoon.svc",
-			want:              "docker-host.lagoon.svc",
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name: "Pod with empty dockerhost annotation value",
@@ -177,26 +324,18 @@ func Test_extractDockerHost(t *testing.T) {
 					},
 				},
 			},
-			defaultDockerHost: "docker-host.lagoon.svc",
-			want:              "",
-		},
-		{
-			name: "Custom default dockerhost",
-			buildPod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:        "test-build-pod",
-					Namespace:   "test-ns",
-					Annotations: map[string]string{},
-				},
-			},
-			defaultDockerHost: "my-custom-default.svc.cluster.local",
-			want:              "my-custom-default.svc.cluster.local",
+			want:    "",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractDockerHost(tt.buildPod, tt.defaultDockerHost)
+			got, err := extractDockerHost(tt.buildPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractDockerHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 			if got != tt.want {
 				t.Errorf("extractDockerHost() = %v, want %v", got, tt.want)
 			}

--- a/internal/controller/build_controller_test.go
+++ b/internal/controller/build_controller_test.go
@@ -42,7 +42,7 @@ func Test_generateScanPodSpec(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Name:  "scanner",
-							Image: scanImageName,
+							Image: "scanImageName",
 							Env: []corev1.EnvVar{
 								{
 									Name:  "INSIGHT_SCAN_IMAGES",
@@ -51,6 +51,14 @@ func Test_generateScanPodSpec(t *testing.T) {
 								{
 									Name:  "NAMESPACE",
 									Value: "testns",
+								},
+								{
+									Name:  "PROJECT",
+									Value: "projectName",
+								},
+								{
+									Name:  "ENVIRONMENT",
+									Value: "environmentName",
 								},
 							},
 							ImagePullPolicy: "Always",
@@ -83,7 +91,7 @@ func Test_generateScanPodSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateScanPodSpec(tt.args.images, tt.args.buildName, tt.args.namespace)
+			got, err := generateScanPodSpec(tt.args.images, "scanImageName", tt.args.buildName, tt.args.namespace, "projectName", "environmentName")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generateScanPodSpec() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/controller/build_controller_test.go
+++ b/internal/controller/build_controller_test.go
@@ -1,0 +1,96 @@
+package controllers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+func Test_generateScanPodSpec(t *testing.T) {
+	type args struct {
+		images    []string
+		buildName string
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *corev1.Pod
+		wantErr bool
+	}{
+		{
+			name:    "No images",
+			args:    args{images: nil, namespace: "testns", buildName: "buildnamehere"},
+			wantErr: true,
+		},
+		{
+			name: "FoundImages",
+			args: args{
+				images:    []string{"image1", "image2"},
+				namespace: "testns",
+				buildName: "buildnamehere",
+			},
+			want: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "testns",
+					Name:      scannerNameFromBuildname("buildnamehere"),
+					Labels:    imageScanPodLabels(),
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "lagoon-deployer",
+					Containers: []corev1.Container{
+						{
+							Name:  "scanner",
+							Image: scanImageName,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "INSIGHT_SCAN_IMAGES",
+									Value: "image1,image2",
+								},
+								{
+									Name:  "NAMESPACE",
+									Value: "testns",
+								},
+							},
+							ImagePullPolicy: "Always",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "lagoon-internal-registry-secret",
+									MountPath: "/home/.docker/",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "lagoon-internal-registry-secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "lagoon-internal-registry-secret",
+									Items: []corev1.KeyToPath{
+										{Key: ".dockerconfigjson", Path: "config.json"},
+									},
+								},
+							},
+						},
+					},
+					RestartPolicy: "Never",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateScanPodSpec(tt.args.images, tt.args.buildName, tt.args.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateScanPodSpec() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("generateScanPodSpec() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/build_controller_test.go
+++ b/internal/controller/build_controller_test.go
@@ -60,6 +60,10 @@ func Test_generateScanPodSpec(t *testing.T) {
 									Name:  "ENVIRONMENT",
 									Value: "environmentName",
 								},
+								{
+									Name:  "DOCKER_HOST",
+									Value: dockerhost,
+								},
 							},
 							ImagePullPolicy: "Always",
 							VolumeMounts: []corev1.VolumeMount{
@@ -91,7 +95,7 @@ func Test_generateScanPodSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateScanPodSpec(tt.args.images, "scanImageName", tt.args.buildName, tt.args.namespace, "projectName", "environmentName")
+			got, err := generateScanPodSpec(tt.args.images, "scanImageName", tt.args.buildName, tt.args.namespace, "projectName", "environmentName", dockerhost)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generateScanPodSpec() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -44,8 +44,6 @@ type ConfigMapReconciler struct {
 }
 
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=configmaps/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=core,resources=configmaps/finalizers,verbs=update
 
 // Gathers insights related Config Maps and ships them to configured endpoints.
 func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/namespace_controller.go
+++ b/internal/controller/namespace_controller.go
@@ -43,9 +43,8 @@ type NamespaceReconciler struct {
 
 const insightsTokenLabel = "lagoon.sh/insights-token"
 
-//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=core,resources=namespaces/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Injects tokens that can be used to post insights to the web service.
 func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Replaces #90 

This PR introduces the functionality for insights-remote to take over insights scanning from the build-deploy tool.

It adds a build-reconciler which monitors for build pods (labelled with lagoon.sh/buildName). If the pod is successfully run, the reconciler will create a scanner pod (see this https://github.com/uselagoon/lagoon-service-images/pull/77) and inject it into the namespace. The scanner pod replicates the existing scanning process inside the build-deploy-tool.

This insight scanner will loaded into the namespace with labels

    "insights.lagoon.sh/scan-status" - name is self explanatory
    "insights.lagoon.sh/imagescanner" - this is important for the network policy, it indicates that this pod should, like the build pod, be able to access the dockerhosts - see https://github.com/uselagoon/lagoon-charts/pull/677

Further, this will read the dockerhost value from the annotation added to the build pod itself and use that to source the images.

Importantly, for users of insights remote, it adds the following two options

    ENABLE_BUILD_SCANNING: (true/false) - setting this to true will kick off the monitoring process and scan completed builds
    BUILD_SCANNER_IMAGE: this allows one to specify which image this is using to do the scanning (currently defaulting to the uselagoon service image described above).This PR introduces the functionality for insights-remote to take over insights scanning from the build-deploy tool.

It adds a build-reconciler which monitors for build pods (labelled with lagoon.sh/buildName). If the pod is successfully run, the reconciler will create a scanner pod (see this https://github.com/uselagoon/lagoon-service-images/pull/77) and inject it into the namespace. The scanner pod replicates the existing scanning process inside the build-deploy-tool.

This insight scanner will loaded into the namespace with labels

    "insights.lagoon.sh/scan-status" - name is self explanatory
    "insights.lagoon.sh/imagescanner" - this is important for the network policy, it indicates that this pod should, like the build pod, be able to access the dockerhosts - see https://github.com/uselagoon/lagoon-charts/pull/677

Further, this will read the dockerhost value from the annotation added to the build pod itself and use that to source the images.

Importantly, for users of insights remote, it adds the following two options

    ENABLE_BUILD_SCANNING: (true/false) - setting this to true will kick off the monitoring process and scan completed builds
    BUILD_SCANNER_IMAGE: this allows one to specify which image this is using to do the scanning (currently defaulting to the uselagoon service image described above).