### PR TITLE
Initial prod only implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The default integration is enabled by starting Insights Remote with the appropri
 The custom integration is enabled by adding the following environment variables in the Lagoon API:
 * LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_ENDPOINT=https://dependency-track.example.com
 * LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY=your-api-key
+* LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_PUSH_PROD_ONLY=true|false — optional; overrides the global `--dependency-track-push-prod-only` flag for this namespace's custom DT instance. When absent, the global default applies.
 
 ### API Key
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -96,6 +96,7 @@ var (
 	dependencyTrackParentProjectNameTemplate string
 	dependencyTrackProjectNameTemplate       string
 	dependencyTrackVersionTemplate           string
+	dependencyTrackPushProdDefault           bool
 )
 
 func init() {
@@ -140,6 +141,7 @@ func main() {
 	flag.StringVar(&dependencyTrackParentProjectNameTemplate, "dependency-track-parent-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}", "The template for the parent project name in Dependency Track.")
 	flag.StringVar(&dependencyTrackProjectNameTemplate, "dependency-track-project-name-template", "{{ .ProjectName }}-{{ .EnvironmentName }}-{{ .ServiceName }}", "The template for the project name in Dependency Track.")
 	flag.StringVar(&dependencyTrackVersionTemplate, "dependency-track-version-template", "unset", "The template for the version in Dependency Track.")
+	flag.BoolVar(&dependencyTrackPushProdDefault, "dependency-track-push-prod-only", true, "By default, dependency track will only push the prod environment, if true, requires explicit overriding.")
 
 	// Controller.
 	var enableLeaderElection bool
@@ -371,6 +373,7 @@ func main() {
 				enableDependencyTrackIntegration,
 				dependencyTrackApiEndpoint,
 				dependencyTrackApiKey,
+				dependencyTrackPushProdDefault,
 				dependencyTrackRootProjectNameTemplate,
 				dependencyTrackParentProjectNameTemplate,
 				dependencyTrackProjectNameTemplate,
@@ -379,6 +382,7 @@ func main() {
 			deptrack.NewCustomPostProcessor(
 				enableDependencyTrackIntegration,
 				mgr.GetClient(),
+				dependencyTrackPushProdDefault,
 				dependencyTrackRootProjectNameTemplate,
 				dependencyTrackParentProjectNameTemplate,
 				dependencyTrackProjectNameTemplate,

--- a/internal/postprocess/dependency_track/custom_postprocess.go
+++ b/internal/postprocess/dependency_track/custom_postprocess.go
@@ -15,13 +15,15 @@ import (
 // CustomPostProcess will send insights for a namespace to a Dependency Track instance configured
 // for that namespace.
 type CustomPostProcess struct {
-	Client    client.Client
-	Templates Templates
+	Client       client.Client
+	Templates    Templates
+	PushProdOnly bool
 }
 
 func NewCustomPostProcessor(
 	enableDependencyTrackIntegration bool,
 	client client.Client,
+	pushProdOnly bool,
 	dependencyTrackRootProjectNameTemplate string,
 	dependencyTrackParentProjectNameTemplate string,
 	dependencyTrackProjectNameTemplate string,
@@ -32,7 +34,8 @@ func NewCustomPostProcessor(
 	}
 
 	return &CustomPostProcess{
-		Client: client,
+		Client:       client,
+		PushProdOnly: pushProdOnly,
 		Templates: newTemplate(
 			dependencyTrackRootProjectNameTemplate,
 			dependencyTrackParentProjectNameTemplate,
@@ -72,6 +75,6 @@ func (d *CustomPostProcess) PostProcess(message internal.LagoonInsightsMessage) 
 		return err
 	}
 
-	err = postProcess(message, d.Templates, client)
+	err = postProcess(message, d.PushProdOnly, d.Templates, client)
 	return err
 }

--- a/internal/postprocess/dependency_track/custom_postprocess.go
+++ b/internal/postprocess/dependency_track/custom_postprocess.go
@@ -3,6 +3,8 @@ package deptrack
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strconv"
 
 	dtrack "github.com/DependencyTrack/client-go"
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +13,28 @@ import (
 	"lagoon.sh/insights-remote/internal/postprocess"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	lagoonEnvDTAPIKey       = "LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY"
+	lagoonEnvDTPushProdOnly = "LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_PUSH_PROD_ONLY"
+)
+
+// resolvePushProdOnly returns the effective pushProdOnly value for a namespace.
+// If the secret data contains a valid bool for lagoonEnvDTPushProdOnly, it overrides
+// the global default. Invalid values log a warning and fall back to globalDefault.
+func resolvePushProdOnly(globalDefault bool, secretData map[string][]byte) bool {
+	val, ok := secretData[lagoonEnvDTPushProdOnly]
+	if !ok || len(val) == 0 {
+		return globalDefault
+	}
+	parsed, err := strconv.ParseBool(string(val))
+	if err != nil {
+		slog.Warn("invalid value for push-prod-only override, using global default",
+			"value", string(val))
+		return globalDefault
+	}
+	return parsed
+}
 
 // CustomPostProcess will send insights for a namespace to a Dependency Track instance configured
 // for that namespace.
@@ -64,18 +88,19 @@ func (d *CustomPostProcess) PostProcess(message internal.LagoonInsightsMessage) 
 		return fmt.Errorf("failed to load custom key: %w", err)
 	}
 
-	if len(secret.Data["LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY"]) == 0 {
+	if len(secret.Data[lagoonEnvDTAPIKey]) == 0 {
 		return fmt.Errorf("failed to load custom key")
 	}
 
-	apiKey := string(secret.Data["LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY"])
+	apiKey := string(secret.Data[lagoonEnvDTAPIKey])
+	effectivePushProdOnly := resolvePushProdOnly(d.PushProdOnly, secret.Data)
 
 	client, err := dtrack.NewClient(apiEndpoint, dtrack.WithAPIKey(apiKey))
 	if err != nil {
 		return err
 	}
 
-	err = postProcess(message, d.PushProdOnly, d.Templates, client)
+	err = postProcess(message, effectivePushProdOnly, d.Templates, client)
 	return err
 }
 

--- a/internal/postprocess/dependency_track/default_postprocess.go
+++ b/internal/postprocess/dependency_track/default_postprocess.go
@@ -8,15 +8,17 @@ import (
 
 // DefaultPostProcess will send insights for all namespaces to a central Dependency Track instance.
 type DefaultPostProcess struct {
-	ApiEndpoint string
-	ApiKey      string
-	Templates   Templates
+	ApiEndpoint  string
+	ApiKey       string
+	Templates    Templates
+	PushProdOnly bool
 }
 
 func NewDefaultPostProcessor(
 	enableDependencyTrackIntegration bool,
 	dependencyTrackApiEndpoint string,
 	dependencyTrackApiKey string,
+	pushProdOnly bool,
 	dependencyTrackRootProjectNameTemplate string,
 	dependencyTrackParentProjectNameTemplate string,
 	dependencyTrackProjectNameTemplate string,
@@ -31,8 +33,9 @@ func NewDefaultPostProcessor(
 	}
 
 	return &DefaultPostProcess{
-		ApiEndpoint: dependencyTrackApiEndpoint,
-		ApiKey:      dependencyTrackApiKey,
+		ApiEndpoint:  dependencyTrackApiEndpoint,
+		ApiKey:       dependencyTrackApiKey,
+		PushProdOnly: pushProdOnly,
 		Templates: newTemplate(
 			dependencyTrackRootProjectNameTemplate,
 			dependencyTrackParentProjectNameTemplate,
@@ -53,6 +56,6 @@ func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage)
 		return err
 	}
 
-	err = postProcess(message, d.Templates, client)
+	err = postProcess(message, d.PushProdOnly, d.Templates, client)
 	return err
 }

--- a/internal/postprocess/dependency_track/dependencyTrack.go
+++ b/internal/postprocess/dependency_track/dependencyTrack.go
@@ -210,6 +210,20 @@ func postProcess(message internal.LagoonInsightsMessage, pushProdOnly bool, temp
 		return err
 	}
 
+	// let's build the tags for this project
+	// specifically, we'll see if we have any details about the service type
+	dtrackTags := []dtrack.Tag{}
+	var environmentType string
+	if val, ok := message.Labels["lagoon.sh/environmentType"]; ok {
+		dtrackTags = append(dtrackTags, dtrack.Tag{Name: fmt.Sprintf("lagoon-environmenttype-%v", val)})
+		environmentType = val
+	}
+
+	if pushProdOnly && environmentType != lagoonShEnvironmentTypeProd {
+		slog.Info("Skipping non-production environment for Dependency Track", "environmentType", environmentType, "project", message.Project, "environment", message.Environment)
+		return nil
+	}
+
 	// Here we iterate over the parent projects, creating them if/when we need
 	// only the last one gets passed to the upload
 	var project *dtrack.Project
@@ -242,20 +256,6 @@ func postProcess(message internal.LagoonInsightsMessage, pushProdOnly bool, temp
 
 	if err != nil {
 		return err
-	}
-
-	// let's build the tags for this project
-	// specifically, we'll see if we have any details about the service type
-	dtrackTags := []dtrack.Tag{}
-	var environmentType string
-	if val, ok := message.Labels["lagoon.sh/environmentType"]; ok {
-		dtrackTags = append(dtrackTags, dtrack.Tag{Name: fmt.Sprintf("lagoon-environmenttype-%v", val)})
-		environmentType = val
-	}
-
-	if pushProdOnly && environmentType != lagoonShEnvironmentTypeProd {
-		slog.Info("Skipping non-production environment for Dependency Track", "environmentType", environmentType, "project", message.Project, "environment", message.Environment)
-		return nil
 	}
 
 	request := dtrack.BOMUploadRequest{

--- a/internal/postprocess/dependency_track/dependencyTrack.go
+++ b/internal/postprocess/dependency_track/dependencyTrack.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log/slog"
 	"text/template"
 	"time"
 
@@ -28,6 +29,8 @@ type writeInfo struct {
 	ProjectName        string
 	ProjectVersion     string
 }
+
+const lagoonShEnvironmentTypeProd = "production"
 
 func newTemplate(
 	dependencyTrackRootProjectNameTemplate string,
@@ -198,7 +201,7 @@ func unzipByteStream(input io.Reader, output io.Writer) error {
 	return err
 }
 
-func postProcess(message internal.LagoonInsightsMessage, templates Templates, client *dtrack.Client) error {
+func postProcess(message internal.LagoonInsightsMessage, pushProdOnly bool, templates Templates, client *dtrack.Client) error {
 	// Now we pull out the necessary information to structure the write in terms of project name and parent.
 	writeInfo, err := getWriteInfo(message, templates)
 	if err != nil {
@@ -242,9 +245,15 @@ func postProcess(message internal.LagoonInsightsMessage, templates Templates, cl
 	// let's build the tags for this project
 	// specifically, we'll see if we have any details about the service type
 	dtrackTags := []dtrack.Tag{}
+	var environmentType string
 	if val, ok := message.Labels["lagoon.sh/environmentType"]; ok {
 		dtrackTags = append(dtrackTags, dtrack.Tag{Name: fmt.Sprintf("lagoon-environmenttype-%v", val)})
+		environmentType = val
+	}
 
+	if pushProdOnly && environmentType != lagoonShEnvironmentTypeProd {
+		slog.Info("Skipping non-production environment for Dependency Track", "environmentType", environmentType, "project", message.Project, "environment", message.Environment)
+		return nil
 	}
 
 	request := dtrack.BOMUploadRequest{

--- a/internal/postprocess/dependency_track/dependencyTrack_test.go
+++ b/internal/postprocess/dependency_track/dependencyTrack_test.go
@@ -242,3 +242,57 @@ func Test_getWriteInfo(t *testing.T) {
 		})
 	}
 }
+
+func Test_resolvePushProdOnly(t *testing.T) {
+	tests := []struct {
+		name          string
+		globalDefault bool
+		secretData    map[string][]byte
+		want          bool
+	}{
+		{
+			name:          "absent key uses global default true",
+			globalDefault: true,
+			secretData:    map[string][]byte{},
+			want:          true,
+		},
+		{
+			name:          "absent key uses global default false",
+			globalDefault: false,
+			secretData:    map[string][]byte{},
+			want:          false,
+		},
+		{
+			name:          "override false overrides global true",
+			globalDefault: true,
+			secretData:    map[string][]byte{lagoonEnvDTPushProdOnly: []byte("false")},
+			want:          false,
+		},
+		{
+			name:          "override true overrides global false",
+			globalDefault: false,
+			secretData:    map[string][]byte{lagoonEnvDTPushProdOnly: []byte("true")},
+			want:          true,
+		},
+		{
+			name:          "invalid value falls back to global default",
+			globalDefault: true,
+			secretData:    map[string][]byte{lagoonEnvDTPushProdOnly: []byte("yes")},
+			want:          true,
+		},
+		{
+			name:          "empty value falls back to global default",
+			globalDefault: false,
+			secretData:    map[string][]byte{lagoonEnvDTPushProdOnly: []byte("")},
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvePushProdOnly(tt.globalDefault, tt.secretData)
+			if got != tt.want {
+				t.Errorf("resolvePushProdOnly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
One of the issues we will experience with the DT integration is the possibility that pushing _everything_ to DT is a risk where a profusion of development branches exist.

This is a first step in adding controls over what gets pushed to DT, making "production" type environments default.