### PR TITLE
Feature max retries dt push

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,8 @@ var (
 	insightsTokenSecret                      string
 	enableNSReconciler                       bool
 	enableCMReconciler                       bool
+	cmReconcilerMaxRetries                   int
+	cmReconcilerMinutesBetweenRetries        int
 	enableInsightDeferred                    bool //TODO: Better names for this
 	enableWebservice                         bool
 	tokenTargetLabel                         string
@@ -119,6 +121,10 @@ func main() {
 		"The cron schedule specifying how often insightType configmaps should be cleared (env var: CLEAR_CONFIGMAP_SCHED).")
 	flag.BoolVar(&enableInsightDeferred, "enable-insights-deferred", false,
 		"Delete insights after certain time (env var: ENABLE_INSIGHTS_DEFERRED).")
+	flag.IntVar(&cmReconcilerMaxRetries, "configmap-reconciler-max-retries", 3,
+		"The number of times the configmap reconciler will attempt to run a post-processor before failing")
+	flag.IntVar(&cmReconcilerMinutesBetweenRetries, "configmap-reconciler-mins-between-retries", 3,
+		"The number of minutes the configmap reconciler will wait before attempting a rerun on a failed post-processor")
 
 	// Insights shipping: web service.
 	flag.BoolVar(&enableNSReconciler, "enable-namespace-reconciler", true,
@@ -232,6 +238,10 @@ func main() {
 	enableInsightDeferred = variables.GetEnvBool("ENABLE_INSIGHTS_DEFERRED", enableInsightDeferred)
 	enableBuildScanning = variables.GetEnvBool("ENABLE_BUILD_SCANNING", enableBuildScanning)
 	buildScannerImage = variables.GetEnv("BUILD_SCANNER_IMAGE", buildScannerImage)
+
+	// Controlling CM post-processor retries
+	cmReconcilerMaxRetries = variables.GetEnvInt("CONFIGMAP_RECONCILER_MAX_RETRIES", cmReconcilerMaxRetries)
+	cmReconcilerMinutesBetweenRetries = variables.GetEnvInt("CONFIGMAP_RECONCILER_MINS_BETWEEN_RETRIES", cmReconcilerMinutesBetweenRetries)
 
 	// Check burn after reading value from environment
 	if variables.GetEnv("BURN_AFTER_READING", "FALSE") == "TRUE" {
@@ -387,9 +397,11 @@ func main() {
 		}
 
 		if err = (&controllers.ConfigMapReconciler{
-			Client:         mgr.GetClient(),
-			Scheme:         mgr.GetScheme(),
-			PostProcessors: postProcessors,
+			Client:                mgr.GetClient(),
+			Scheme:                mgr.GetScheme(),
+			PostProcessors:        postProcessors,
+			MinutesBetweenRetries: cmReconcilerMinutesBetweenRetries,
+			MaxNumberOfRetries:    cmReconcilerMaxRetries,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ConfigMap")
 			os.Exit(1)

--- a/cmlib/cmlib.go
+++ b/cmlib/cmlib.go
@@ -2,40 +2,65 @@ package cmlib
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func LabelCM(ctx context.Context, r client.Client, configMap corev1.ConfigMap, labelKey string, labelValue string) error {
-	log := log.FromContext(ctx)
-	labels := configMap.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
-	}
-
-	labels[labelKey] = labelValue
-	configMap.SetLabels(labels)
-
-	if err := r.Update(ctx, &configMap); err != nil {
-		log.Error(err, "Unable to update configMap - setting labels")
-		return err
-	}
-	return nil
+	return BatchUpdateCM(ctx, r, configMap, map[string]string{
+		labelKey: labelValue,
+	}, nil)
 }
 
 func AnnotateCM(ctx context.Context, r client.Client, configMap corev1.ConfigMap, annotationKey string, annotationValue string) error {
+	return BatchUpdateCM(ctx, r, configMap, nil, map[string]string{
+		annotationKey: annotationValue,
+	})
+}
+
+func BatchUpdateCM(ctx context.Context, r client.Client, configMap corev1.ConfigMap, updatedLabels map[string]string, updatedAnnotations map[string]string) error {
 	log := log.FromContext(ctx)
-	annotations := configMap.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
+	if len(updatedLabels) == 0 && len(updatedAnnotations) == 0 {
+		return errors.New("no updates passed to BatchUpdateCM")
 	}
 
-	annotations[annotationKey] = annotationValue
-	configMap.SetAnnotations(annotations)
+	updatedItems := []string{}
+
+	if len(updatedLabels) > 0 {
+		labels := configMap.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		for labelKey, labelValue := range updatedLabels {
+			labels[labelKey] = labelValue
+		}
+
+		configMap.SetLabels(labels)
+		updatedItems = append(updatedItems, "Labels")
+	}
+
+	if len(updatedAnnotations) > 0 {
+		annotations := configMap.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		for key, value := range updatedAnnotations {
+			annotations[key] = value
+		}
+
+		configMap.SetAnnotations(annotations)
+		updatedItems = append(updatedItems, "Annotations")
+	}
 
 	if err := r.Update(ctx, &configMap); err != nil {
-		log.Error(err, "Unable to update configMap - setting annotations")
+		log.Error(err, fmt.Sprintf("unable to update configMap - setting: %v", strings.Join(updatedItems, ",")))
 		return err
 	}
 	return nil

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -45,7 +45,7 @@ type ConfigMapReconciler struct {
 	MaxNumberOfRetries    int
 }
 
-const postProcRetriesAnnotationKey = "core.insights.lagoon.sh/postproc-retries"
+const postProcRetriesAnnotationKey = "insights.lagoon.sh/retries"
 const maxRetryExceededLabelKey = "insights.lagoon.sh/max-retry-exceeded"
 const successfulPostProcessRun = "success"
 const failedPostProcessRun = "failure"

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -43,6 +43,11 @@ type ConfigMapReconciler struct {
 	PostProcessors []postprocess.PostProcessor
 }
 
+const minutesBetweenRetries = 5
+const maxNumberOfRetries = 2
+const postProcRetriesAnnotationKey = "core.insights.lagoon.sh/postproc-retries"
+const maxRetryExceededLabelKey = "insights.lagoon.sh/max-retry-exceeded"
+
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Gathers insights related Config Maps and ships them to configured endpoints.
@@ -121,6 +126,16 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	retryPostprocessors := []string{}
 	completePostProcessors := []string{}
 
+	var numberOfRetries int64
+
+	if retriesAnnotation, ok := insightsMessage.Annotations[postProcRetriesAnnotationKey]; ok {
+		var err error
+		numberOfRetries, err = strconv.ParseInt(retriesAnnotation, 10, 64)
+		if err != nil {
+			log.Info(fmt.Sprintf("unable to read insights %v label - setting to / assuming first run. Error: %v\n", postProcRetriesAnnotationKey, err.Error()))
+		}
+	}
+
 	for _, processor := range r.PostProcessors {
 		if processor != nil {
 
@@ -155,10 +170,20 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	updateLabels := map[string]string{}
 	if len(retryPostprocessors) > 0 {
 		//In this case what we want to do is defer the processing to a couple minutes from now
-		updateLabels[internal.InsightsWriteDeferred] = minutesFromNow(5)
+		updateLabels[internal.InsightsWriteDeferred] = minutesFromNow(minutesBetweenRetries)
+		numberOfRetries += 1
+
+		if numberOfRetries > maxNumberOfRetries { // We have now reached the end of the line.
+			updateLabels[maxRetryExceededLabelKey] = "MAX_RETRY_EXCEEDED"
+			log.Info(fmt.Sprintf("Max post-processor retries (%v) exceeded for configmap %v/%v - no further retries will be attempted", maxNumberOfRetries, configMap.Namespace, configMap.Name))
+		}
+
 	} else {
 		updateAnnotations[internal.InsightsUpdatedAnnotationLabel] = time.Now().UTC().Format(time.RFC3339)
 	}
+
+	// let's write the number of retries either way
+	updateAnnotations[postProcRetriesAnnotationKey] = strconv.FormatInt(numberOfRetries, 10)
 
 	err := cmlib.BatchUpdateCM(ctx, r.Client, configMap, updateLabels, updateAnnotations)
 
@@ -196,6 +221,28 @@ func insightLabelsOnlyPredicate() predicate.Predicate {
 	}
 }
 
+// Let's set up a predicate that filters out anything without a particular label AND
+// we don't care about delete events
+func insightMaxRetryPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			if labelExists(maxRetryExceededLabelKey, event.Object) {
+				return false
+			}
+			return true
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			if labelExists(maxRetryExceededLabelKey, event.ObjectNew) {
+				return false
+			}
+			return true
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+	}
+}
+
 func labelExists(label string, event client.Object) bool {
 	for k, v := range event.GetLabels() {
 		if k == label || v == label {
@@ -220,6 +267,7 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.ConfigMap{}).
 		WithEventFilter(insightLabelsOnlyPredicate()).
+		WithEventFilter(insightMaxRetryPredicate()).
 		Complete(r)
 }
 

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -118,30 +118,49 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Here we run the post processors
-	retryPostprocessing := false
+	retryPostprocessors := []string{}
+	completePostProcessors := []string{}
+
 	for _, processor := range r.PostProcessors {
 		if processor != nil {
+
+			// we skip if the processor has been successful in the past
+			if val, ok := insightsMessage.Annotations[processor.Label()]; ok {
+				if val == "success" {
+					completePostProcessors = append(completePostProcessors, processor.Label())
+					continue
+				}
+			}
+
 			err := processor.PostProcess(insightsMessage)
 			if err != nil {
 				log.Error(err, "Post processor failed")
-				retryPostprocessing = true
+				retryPostprocessors = append(retryPostprocessors, processor.Label())
+				continue
 			}
+			completePostProcessors = append(completePostProcessors, processor.Label())
 		}
 	}
 
-	if retryPostprocessing {
-		// In this case what we want to do is defer the processing to a couple minutes from now
-		err := cmlib.LabelCM(ctx, r.Client, configMap, internal.InsightsWriteDeferred, minutesFromNow(5))
+	// let's build our comprehensive annotation and label updates
 
-		if err != nil {
-			log.Error(err, "Unable to update configmap")
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, err
+	updateAnnotations := map[string]string{}
+	for _, v := range completePostProcessors {
+		updateAnnotations[v] = "success"
+	}
+	for _, v := range retryPostprocessors {
+		updateAnnotations[v] = "failure"
 	}
 
-	err := cmlib.AnnotateCM(ctx, r.Client, configMap, internal.InsightsUpdatedAnnotationLabel, time.Now().UTC().Format(time.RFC3339))
+	updateLabels := map[string]string{}
+	if len(retryPostprocessors) > 0 {
+		//In this case what we want to do is defer the processing to a couple minutes from now
+		updateLabels[internal.InsightsWriteDeferred] = minutesFromNow(5)
+	} else {
+		updateAnnotations[internal.InsightsUpdatedAnnotationLabel] = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	err := cmlib.BatchUpdateCM(ctx, r.Client, configMap, updateLabels, updateAnnotations)
 
 	if err != nil {
 		log.Error(err, "Unable to update configmap")

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -39,12 +39,12 @@ import (
 // ConfigMapReconciler reconciles a ConfigMap object
 type ConfigMapReconciler struct {
 	client.Client
-	Scheme         *runtime.Scheme
-	PostProcessors []postprocess.PostProcessor
+	Scheme                *runtime.Scheme
+	PostProcessors        []postprocess.PostProcessor
+	MinutesBetweenRetries int
+	MaxNumberOfRetries    int
 }
 
-const minutesBetweenRetries = 5
-const maxNumberOfRetries = 2
 const postProcRetriesAnnotationKey = "core.insights.lagoon.sh/postproc-retries"
 const maxRetryExceededLabelKey = "insights.lagoon.sh/max-retry-exceeded"
 const successfulPostProcessRun = "success"
@@ -170,12 +170,12 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	updateLabels := map[string]string{}
 	if len(retryPostprocessors) > 0 { // There was a problem writing these data to one of the endpoints
 		//In this case what we want to do is defer the processing to a couple minutes from now
-		updateLabels[internal.InsightsWriteDeferred] = minutesFromNow(minutesBetweenRetries)
+		updateLabels[internal.InsightsWriteDeferred] = minutesFromNow(r.MinutesBetweenRetries)
 		numberOfRetries += 1
 
-		if numberOfRetries > maxNumberOfRetries { // We have now reached the end of the line.
+		if numberOfRetries > int64(r.MaxNumberOfRetries) { // We have now reached the end of the line.
 			updateLabels[maxRetryExceededLabelKey] = "MAX_RETRY_EXCEEDED"
-			log.Info(fmt.Sprintf("Max post-processor retries (%v) exceeded for configmap %v/%v - no further retries will be attempted", maxNumberOfRetries, configMap.Namespace, configMap.Name))
+			log.Info(fmt.Sprintf("Max post-processor retries (%v) exceeded for configmap %v/%v - no further retries will be attempted", r.MaxNumberOfRetries, configMap.Namespace, configMap.Name))
 		}
 
 	} else { // we've managed to get everything stowed away, let's mark this as done.

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -47,6 +47,8 @@ const minutesBetweenRetries = 5
 const maxNumberOfRetries = 2
 const postProcRetriesAnnotationKey = "core.insights.lagoon.sh/postproc-retries"
 const maxRetryExceededLabelKey = "insights.lagoon.sh/max-retry-exceeded"
+const successfulPostProcessRun = "success"
+const failedPostProcessRun = "failure"
 
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
@@ -132,16 +134,18 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		var err error
 		numberOfRetries, err = strconv.ParseInt(retriesAnnotation, 10, 64)
 		if err != nil {
+			numberOfRetries = 0
 			log.Info(fmt.Sprintf("unable to read insights %v label - setting to / assuming first run. Error: %v\n", postProcRetriesAnnotationKey, err.Error()))
 		}
 	}
 
+	updateAnnotations := map[string]string{}
 	for _, processor := range r.PostProcessors {
 		if processor != nil {
 
 			// we skip if the processor has been successful in the past
 			if val, ok := insightsMessage.Annotations[processor.Label()]; ok {
-				if val == "success" {
+				if val == successfulPostProcessRun {
 					completePostProcessors = append(completePostProcessors, processor.Label())
 					continue
 				}
@@ -150,25 +154,21 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			err := processor.PostProcess(insightsMessage)
 			if err != nil {
 				log.Error(err, "Post processor failed")
+				// We line this up for retrying the next time around
 				retryPostprocessors = append(retryPostprocessors, processor.Label())
+				// let's update our annotations to set this as a failure
+				updateAnnotations[processor.Label()] = failedPostProcessRun
+				// We'll also want to set or update an annotation telling us why it failed
+				updateAnnotations[fmt.Sprintf("%v-error", processor.Label())] = err.Error()
 				continue
 			}
 			completePostProcessors = append(completePostProcessors, processor.Label())
+			updateAnnotations[processor.Label()] = successfulPostProcessRun
 		}
 	}
 
-	// let's build our comprehensive annotation and label updates
-
-	updateAnnotations := map[string]string{}
-	for _, v := range completePostProcessors {
-		updateAnnotations[v] = "success"
-	}
-	for _, v := range retryPostprocessors {
-		updateAnnotations[v] = "failure"
-	}
-
 	updateLabels := map[string]string{}
-	if len(retryPostprocessors) > 0 {
+	if len(retryPostprocessors) > 0 { // There was a problem writing these data to one of the endpoints
 		//In this case what we want to do is defer the processing to a couple minutes from now
 		updateLabels[internal.InsightsWriteDeferred] = minutesFromNow(minutesBetweenRetries)
 		numberOfRetries += 1
@@ -178,7 +178,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			log.Info(fmt.Sprintf("Max post-processor retries (%v) exceeded for configmap %v/%v - no further retries will be attempted", maxNumberOfRetries, configMap.Namespace, configMap.Name))
 		}
 
-	} else {
+	} else { // we've managed to get everything stowed away, let's mark this as done.
 		updateAnnotations[internal.InsightsUpdatedAnnotationLabel] = time.Now().UTC().Format(time.RFC3339)
 	}
 

--- a/internal/postprocess/dependency_track/custom_postprocess.go
+++ b/internal/postprocess/dependency_track/custom_postprocess.go
@@ -75,3 +75,7 @@ func (d *CustomPostProcess) PostProcess(message internal.LagoonInsightsMessage) 
 	err = postProcess(message, d.Templates, client)
 	return err
 }
+
+func (p *CustomPostProcess) Label() string {
+	return "postproc.core.insights.lagoon.sh/custom-deptrack"
+}

--- a/internal/postprocess/dependency_track/custom_postprocess.go
+++ b/internal/postprocess/dependency_track/custom_postprocess.go
@@ -77,5 +77,5 @@ func (d *CustomPostProcess) PostProcess(message internal.LagoonInsightsMessage) 
 }
 
 func (p *CustomPostProcess) Label() string {
-	return "postproc.core.insights.lagoon.sh/custom-deptrack"
+	return "dependencytrack.insights.lagoon.sh/custom-status"
 }

--- a/internal/postprocess/dependency_track/default_postprocess.go
+++ b/internal/postprocess/dependency_track/default_postprocess.go
@@ -58,5 +58,5 @@ func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage)
 }
 
 func (p *DefaultPostProcess) Label() string {
-	return "postproc.core.insights.lagoon.sh/default-deptrack"
+	return "dependencytrack.insights.lagoon.sh/default-status"
 }

--- a/internal/postprocess/dependency_track/default_postprocess.go
+++ b/internal/postprocess/dependency_track/default_postprocess.go
@@ -56,3 +56,7 @@ func (d *DefaultPostProcess) PostProcess(message internal.LagoonInsightsMessage)
 	err = postProcess(message, d.Templates, client)
 	return err
 }
+
+func (p *DefaultPostProcess) Label() string {
+	return "postproc.core.insights.lagoon.sh/default-deptrack"
+}

--- a/internal/postprocess/insights_core/insights_core.go
+++ b/internal/postprocess/insights_core/insights_core.go
@@ -28,7 +28,7 @@ func NewPostProcessor(
 }
 
 func (p *PostProcess) Label() string {
-	return "postproc.core.insights.lagoon.sh/insights-core-handler"
+	return "core.insights.lagoon.sh/status"
 }
 
 func (p *PostProcess) PostProcess(message internal.LagoonInsightsMessage) error {

--- a/internal/postprocess/insights_core/insights_core.go
+++ b/internal/postprocess/insights_core/insights_core.go
@@ -27,6 +27,10 @@ func NewPostProcessor(
 	}
 }
 
+func (p *PostProcess) Label() string {
+	return "postproc.core.insights.lagoon.sh/insights-core-handler"
+}
+
 func (p *PostProcess) PostProcess(message internal.LagoonInsightsMessage) error {
 	if message.Annotations["core.insights.lagoon.sh/enabled"] != "true" {
 		return nil

--- a/internal/postprocess/postprocess.go
+++ b/internal/postprocess/postprocess.go
@@ -7,4 +7,5 @@ import (
 type PostProcessor interface {
 	// PostProcess processes insights. Must be idempotent.
 	PostProcess(message internal.LagoonInsightsMessage) error
+	Label() string
 }


### PR DESCRIPTION
This PR introduces retry logic for the configmap post-processors.

* It introduces a way to avoid having all post-processors run if there is only a partial failure. Only failed processes rerun.
* It annotates the configmap to specify which of the post-processors failed
* Tracks the error itself in an annotation
* Introduces flags and env vars for controlling this bahaviour