### PR TITLE
Gate e2e tests and skip e2e tests unless explicitly invoked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ KIND = $(realpath ./local-dev/kind)
 
 ARCH := $(shell uname | tr '[:upper:]' '[:lower:]')
 
+SKIP_KUBECONTEXT_CHECK = false
+
 .PHONY: local-dev/kind
 local-dev/kind:
 ifeq ($(KIND_VERSION), $(shell kind version 2>/dev/null | sed -nE 's/kind (v[0-9.]+).*/\1/p'))
@@ -349,7 +351,7 @@ kind/re-test-e2e:
 	LAGOON_KIND_CIDR_BLOCK=$$(docker network inspect $(KIND_NETWORK) | $(JQ) '.[].Containers[].IPv4Address' | tr -d '"') && \
 	export KIND_NODE_IP=$$(echo $${LAGOON_KIND_CIDR_BLOCK%???} | awk -F'.' '{print $$1,$$2,$$3,240}' OFS='.') && \
 	$(KIND) export kubeconfig --name=$(KIND_CLUSTER) && \
-	$(MAKE) test-e2e
+	$(MAKE) test-e2e SKIP_KUBECONTEXT_CHECK=true
 
 .PHONY: clean
 kind/clean:
@@ -359,7 +361,13 @@ kind/clean:
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up inside github action.
 test-e2e: generate-broker-certs
-	go test ./test/e2e/ -v -ginkgo.v
+	@if [ $(SKIP_KUBECONTEXT_CHECK) = false ]; then \
+		echo "==================================================="; \
+		echo "WARNING: You are targeting $$($(KUBECTL) config current-context)"; \
+		echo "==================================================="; \
+		echo -n "Do you want to continue? [y/N] " && read ans && if [[ $${ans:-'N'} = 'y' ]]; then echo -n ""; else exit 1; fi \
+	fi
+	go test ./test/e2e/ -v -ginkgo.v -e2e
 
 .PHONY: github/test-e2e
 github/test-e2e: local-dev/tools install-ingress test-e2e

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ test-e2e: generate-broker-certs
 		echo "==================================================="; \
 		echo "WARNING: You are targeting $$($(KUBECTL) config current-context)"; \
 		echo "==================================================="; \
-		echo -n "Do you want to continue? [y/N] " && read ans && if [[ $${ans:-'N'} = 'y' ]]; then echo -n ""; else exit 1; fi \
+		echo -n "Do you want to continue? [y/N] " && read ans && if [[ $${ans:-'N'} = 'y' ]]; then echo -n ""; else exit 1; fi; \
 	fi
 	go test ./test/e2e/ -v -ginkgo.v -e2e
 

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,8 @@ test-e2e: generate-broker-certs
 	go test ./test/e2e/ -v -ginkgo.v -e2e
 
 .PHONY: github/test-e2e
-github/test-e2e: local-dev/tools install-ingress test-e2e
+github/test-e2e: local-dev/tools install-ingress
+	$(MAKE) test-e2e SKIP_KUBECONTEXT_CHECK=true
 
 .PHONY: kind/set-kubeconfig
 kind/set-kubeconfig:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package e2e
 
 import (
+	"flag"
 	"fmt"
 	"testing"
-
-	"flag"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,12 +20,19 @@ import (
 	"fmt"
 	"testing"
 
+	"flag"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
 // Run e2e tests using the Ginkgo runner.
+var runIntegration = flag.Bool("e2e", false, "run e2e tests")
+
 func TestE2E(t *testing.T) {
+	if !*runIntegration {
+		t.Skip("Skipping e2e tests; use -e2e to run them")
+	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Starting insights-remote suite\n")
 	ginkgo.RunSpecs(t, "e2e suite")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 // Run e2e tests using the Ginkgo runner.
-var runE2Etests = flag.Bool("e2e", false, "run e2e tests")
+var runE2ETests = flag.Bool("e2e", false, "run e2e tests")
 
 func TestE2E(t *testing.T) {
-	if !*runE2Etests {
+	if !*runE2ETests {
 		t.Skip("Skipping e2e tests; use -e2e to run them")
 	}
 	gomega.RegisterFailHandler(ginkgo.Fail)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 // Run e2e tests using the Ginkgo runner.
-var runIntegration = flag.Bool("e2e", false, "run e2e tests")
+var runE2Etests = flag.Bool("e2e", false, "run e2e tests")
 
 func TestE2E(t *testing.T) {
-	if !*runIntegration {
+	if !*runE2Etests {
 		t.Skip("Skipping e2e tests; use -e2e to run them")
 	}
 	gomega.RegisterFailHandler(ginkgo.Fail)


### PR DESCRIPTION
This pull request introduces a safety check to prevent accidental execution of end-to-end (e2e) tests against the wrong Kubernetes context, and adds a flag to explicitly enable e2e test runs. The changes ensure that users are warned before running potentially destructive tests, and that automated environments can bypass the prompt as needed.

**E2E Test Safety and Execution Improvements:**

* Added a prompt to the `test-e2e` Makefile target that warns users of the current Kubernetes context and asks for confirmation before proceeding, unless `SKIP_KUBECONTEXT_CHECK` is set to true. This helps prevent accidental test runs against production or unintended clusters.
* Updated `kind/re-test-e2e` and `github/test-e2e` Makefile targets to set `SKIP_KUBECONTEXT_CHECK=true`, allowing automated environments (like CI) to skip the context confirmation prompt. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L352-R354) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L362-R374)
* Introduced a new Go test flag `-e2e` in `e2e_suite_test.go`. The e2e tests will now only run if this flag is provided, otherwise they are skipped. This prevents accidental execution of e2e tests during regular test runs. [[1]](diffhunk://#diff-93b46b0715181c9cf397eed60862261b7839ff721599fcc393a393b9edea610bR20) [[2]](diffhunk://#diff-93b46b0715181c9cf397eed60862261b7839ff721599fcc393a393b9edea610bR29-R34)

**Makefile Variable Management:**

* Added a `SKIP_KUBECONTEXT_CHECK` variable to the Makefile to control the context check behavior for e2e tests.