### PR TITLE
Refactor web auth to dry out token extraction logic

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 type AuthHeader struct {
-	Authorization string `header:"Authorization"`
+	Authorization string `header:"Authorization" binding:"required"`
 }
 
 // routerInstance is used to share state
@@ -24,8 +24,16 @@ type routerInstance struct {
 }
 
 func SetupRouter(secret string, messageQWriter func(data []byte) error, writeToQueue bool) *gin.Engine {
-	router := gin.Default()
+
+	router := gin.New()
+
+	// set up the standard middlewares
+	router.Use(gin.Recovery())
+	router.Use(gin.Logger())
+	router.Use(TokenParserMiddleware(secret))
+
 	r := routerInstance{secret: secret}
+
 	r.MessageQWriter = messageQWriter
 	r.WriteToQueue = writeToQueue
 	router.POST("/facts", r.writeFacts)
@@ -46,17 +54,14 @@ func (r *routerInstance) deleteFacts(c *gin.Context) {
 }
 
 func generateDeletionMessage(c *gin.Context, r *routerInstance, deletionType string) {
-	h := &AuthHeader{}
-	if err := c.ShouldBindHeader(&h); err != nil {
-		c.JSON(http.StatusOK, err)
-	}
 
-	namespace, err := tokens.ValidateAndExtractNamespaceDetailsFromToken(r.secret, h.Authorization)
+	n, exists := c.Get("namespace")
+	namespace, ok := n.(tokens.NamespaceDetails)
 
-	if err != nil {
+	if !exists || !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"status":  "unauthorized",
-			"message": err.Error(),
+			"message": "unauthorized",
 		})
 		return
 	}
@@ -98,17 +103,13 @@ func generateDeletionMessage(c *gin.Context, r *routerInstance, deletionType str
 
 func (r *routerInstance) writeProblems(c *gin.Context) {
 
-	h := &AuthHeader{}
-	if err := c.ShouldBindHeader(&h); err != nil {
-		c.JSON(http.StatusOK, err)
-	}
+	n, exists := c.Get("namespace")
+	namespace, ok := n.(tokens.NamespaceDetails)
 
-	namespace, err := tokens.ValidateAndExtractNamespaceDetailsFromToken(r.secret, h.Authorization)
-
-	if err != nil {
+	if !exists || !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"status":  "unauthorized",
-			"message": err.Error(),
+			"message": "unauthorized",
 		})
 		return
 	}
@@ -118,7 +119,7 @@ func (r *routerInstance) writeProblems(c *gin.Context) {
 	details := &internal.Problems{Type: "direct.problems"}
 	problemList := []internal.Problem(nil)
 
-	if err = c.ShouldBindJSON(&problemList); err != nil {
+	if err := c.ShouldBindJSON(&problemList); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"status":  "Unable to parse incoming data",
 			"message": err.Error(),
@@ -181,21 +182,16 @@ func (r *routerInstance) writeToQueue(c *gin.Context, jsonRep []byte) error {
 
 func (r *routerInstance) writeFacts(c *gin.Context) {
 
-	h := &AuthHeader{}
-	if err := c.ShouldBindHeader(&h); err != nil {
-		c.JSON(http.StatusOK, err)
-	}
+	n, exists := c.Get("namespace")
+	namespace, ok := n.(tokens.NamespaceDetails)
 
-	namespace, err := tokens.ValidateAndExtractNamespaceDetailsFromToken(r.secret, h.Authorization)
-
-	if err != nil {
+	if !exists || !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"status":  "unauthorized",
-			"message": err.Error(),
+			"message": "unauthorized",
 		})
 		return
 	}
-
 	fmt.Println("Going to write to namespace ", namespace)
 
 	//TODO: drop "InsightsType" for Type of the form "direct.fact"/"direct.problem"
@@ -205,7 +201,7 @@ func (r *routerInstance) writeFacts(c *gin.Context) {
 	ByteBody, _ := io.ReadAll(c.Request.Body)
 
 	factList := []internal.Fact(nil)
-	if err = json.Unmarshal(ByteBody, &factList); err != nil { // it might just be they're passing the "big" version with all details
+	if err := json.Unmarshal(ByteBody, &factList); err != nil { // it might just be they're passing the "big" version with all details
 		if err = json.Unmarshal(ByteBody, details); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"status":  "Unable to parse incoming data",

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"k8s.io/apimachinery/pkg/util/json"
 	"lagoon.sh/insights-remote/internal"
-	"lagoon.sh/insights-remote/internal/tokens"
 )
 
 type AuthHeader struct {
@@ -55,10 +54,8 @@ func (r *routerInstance) deleteFacts(c *gin.Context) {
 
 func generateDeletionMessage(c *gin.Context, r *routerInstance, deletionType string) {
 
-	n, exists := c.Get("namespace")
-	namespace, ok := n.(tokens.NamespaceDetails)
-
-	if !exists || !ok {
+	namespace, ok := GetNamespaceDetails(c)
+	if !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"status":  "unauthorized",
 			"message": "unauthorized",
@@ -103,10 +100,8 @@ func generateDeletionMessage(c *gin.Context, r *routerInstance, deletionType str
 
 func (r *routerInstance) writeProblems(c *gin.Context) {
 
-	n, exists := c.Get("namespace")
-	namespace, ok := n.(tokens.NamespaceDetails)
-
-	if !exists || !ok {
+	namespace, ok := GetNamespaceDetails(c)
+	if !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"status":  "unauthorized",
 			"message": "unauthorized",
@@ -182,10 +177,8 @@ func (r *routerInstance) writeToQueue(c *gin.Context, jsonRep []byte) error {
 
 func (r *routerInstance) writeFacts(c *gin.Context) {
 
-	n, exists := c.Get("namespace")
-	namespace, ok := n.(tokens.NamespaceDetails)
-
-	if !exists || !ok {
+	namespace, ok := GetNamespaceDetails(c)
+	if !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"status":  "unauthorized",
 			"message": "unauthorized",

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/json"
 	"lagoon.sh/insights-remote/internal"
@@ -187,4 +188,49 @@ func TestProblemDeletionRoute(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHeaderMiddleware(t *testing.T) {
+	defer resetWriterOutput()
+	router := SetupRouter(secretTestTokenSecret, messageQueueWriter, true)
+
+	router.POST("/getnamespacetest", func(c *gin.Context) {
+		val, exists := c.Get("namespace")
+		if !exists {
+			c.XML(http.StatusBadRequest, "failed")
+		}
+		c.XML(http.StatusOK, val)
+	})
+
+	w := httptest.NewRecorder()
+
+	token, err := tokens.GenerateTokenForNamespace(secretTestTokenSecret, tokens.NamespaceDetails{
+		Namespace:       secretTestNamespace,
+		EnvironmentId:   testEnvironmentId,
+		ProjectName:     "Test",
+		EnvironmentName: "Test",
+	})
+
+	require.NoError(t, err)
+
+	// First, let's test a failure
+
+	var bodyString []byte
+	req, _ := http.NewRequest(http.MethodPost, "/getnamespacetest", bytes.NewBuffer(bodyString))
+	req.Header.Set("Authorization", "busted")
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Now we get success
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest(http.MethodPost, "/getnamespacetest", bytes.NewBuffer(bodyString))
+	req2.Header.Set("Authorization", token)
+	req2.Header.Set("Content-Type", "application/xml")
+	router.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Contains(t, w2.Body.String(), secretTestNamespace)
+
 }

--- a/internal/service/token_middleware.go
+++ b/internal/service/token_middleware.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"lagoon.sh/insights-remote/internal/tokens"
+)
+
+// TokenParserMiddleware is a context aware middleware
+func TokenParserMiddleware(secret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		h := &AuthHeader{}
+		err := c.ShouldBindHeader(&h)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, "Missing bearer token")
+			c.Abort()
+			return
+		}
+
+		namespace, err := tokens.ValidateAndExtractNamespaceDetailsFromToken(secret, h.Authorization)
+
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"status":  "unauthorized",
+				"message": err.Error(),
+			})
+			c.Abort()
+			return
+		}
+		c.Set("namespace", namespace)
+		c.Next()
+	}
+}

--- a/internal/service/token_middleware.go
+++ b/internal/service/token_middleware.go
@@ -32,3 +32,14 @@ func TokenParserMiddleware(secret string) gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+// GetNamespaceDetails retrieves the authenticated namespace from the gin context.
+// It should only be called in handlers protected by TokenParserMiddleware.
+func GetNamespaceDetails(c *gin.Context) (tokens.NamespaceDetails, bool) {
+	n, exists := c.Get("namespace")
+	if !exists {
+		return tokens.NamespaceDetails{}, false
+	}
+	namespace, ok := n.(tokens.NamespaceDetails)
+	return namespace, ok
+}

--- a/internal/tokens/jwt.go
+++ b/internal/tokens/jwt.go
@@ -37,6 +37,10 @@ func ValidateAndExtractNamespaceDetailsFromToken(key, token string) (NamespaceDe
 		return []byte(key), nil
 	})
 
+	if err != nil {
+		return NamespaceDetails{}, err
+	}
+
 	ret := NamespaceDetails{}
 
 	if claims, ok := outToken.Claims.(jwt.MapClaims); ok && outToken.Valid {


### PR DESCRIPTION
This PR takes the repeated token extraction and check and moves it into a middleware.