### PR TITLE
Adds googles patent license to review config

### DIFF
--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -10,6 +10,8 @@ allow-licenses:
 - 'Python-2.0'
 - 'X11'
 - 'Zlib'
+# Google's patent licence for Go
+- 'LicenseRef-scancode-google-patent-license-golang'
 
 allow-dependencies-licenses:
 # this action is GPL-3 but it is only used in CI


### PR DESCRIPTION
This pull request makes a minor update to the dependency review configuration by allowing Google's patent license for Go. This ensures that dependencies under this license are permitted in the project.

* [`.github/dependency-review-config.yaml`](diffhunk://#diff-c677702e47fe70f192761167cdcbb4302c123a634d301ba015781f8ad8112bedR13-R14): Added `'LicenseRef-scancode-google-patent-license-golang'` to the list of allowed licenses.